### PR TITLE
Restore opened collections across app restarts

### DIFF
--- a/apps/desktop/src-tauri/src/storage/state.rs
+++ b/apps/desktop/src-tauri/src/storage/state.rs
@@ -32,10 +32,11 @@ impl Default for WindowState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct PersistedState {
     pub tabs: Vec<PersistedTab>,
     pub active_tab_index: Option<usize>,
+    pub collection_paths: Vec<String>,
     #[serde(default)]
     pub window_state: Option<WindowState>,
 }
@@ -64,4 +65,60 @@ pub fn save_persisted_state(path: &Path, state: &PersistedState) -> Result<(), S
     std::fs::rename(&tmp_path, path).map_err(|e| format!("Failed to rename state file: {e}"))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_persisted_state_defaults_collection_paths_for_legacy_files() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        std::fs::write(
+            &path,
+            r#"{
+  "tabs": [
+    {
+      "filePath": "/tmp/users.yaml",
+      "collectionPath": "/tmp/apiark"
+    }
+  ],
+  "activeTabIndex": 0
+}"#,
+        )
+        .unwrap();
+
+        let state = load_persisted_state(&path);
+
+        assert_eq!(state.tabs.len(), 1);
+        assert_eq!(state.tabs[0].file_path, "/tmp/users.yaml");
+        assert_eq!(state.tabs[0].collection_path, "/tmp/apiark");
+        assert_eq!(state.active_tab_index, Some(0));
+        assert!(state.collection_paths.is_empty());
+        assert!(state.window_state.is_none());
+    }
+
+    #[test]
+    fn save_persisted_state_round_trips_collection_paths() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        let state = PersistedState {
+            tabs: vec![],
+            active_tab_index: None,
+            collection_paths: vec!["/tmp/apiark".to_string(), "/tmp/other".to_string()],
+            window_state: Some(WindowState::default()),
+        };
+
+        save_persisted_state(&path, &state).unwrap();
+        let loaded = load_persisted_state(&path);
+
+        assert_eq!(loaded.collection_paths, state.collection_paths);
+        assert!(loaded.tabs.is_empty());
+        assert_eq!(loaded.active_tab_index, None);
+        assert!(loaded.window_state.is_some());
+    }
 }

--- a/apps/desktop/src/stores/tab-store.ts
+++ b/apps/desktop/src/stores/tab-store.ts
@@ -22,6 +22,7 @@ import {
 import { useEnvironmentStore } from "./environment-store";
 import { useSettingsStore } from "./settings-store";
 import { useConsoleStore } from "./console-store";
+import { useCollectionStore } from "./collection-store";
 
 interface TabState {
   tabs: Tab[];
@@ -949,6 +950,12 @@ export const useTabStore = create<TabState>((set, get) => ({
 
   persistTabs: () => {
     const { tabs, activeTabId } = get();
+    // Persist open collections independently so the sidebar restores even
+    // when the user never opened a request tab from that collection.
+    const collectionPaths = Array.from(
+      new Set(useCollectionStore.getState().collections.map((collection) => collection.path)),
+    );
+
     // Only persist file-backed tabs (exclude ephemeral WS/SSE tabs), deduplicated
     const seen = new Set<string>();
     const persistedTabs = tabs
@@ -977,6 +984,7 @@ export const useTabStore = create<TabState>((set, get) => ({
     savePersistedState({
       tabs: persistedTabs,
       activeTabIndex: activeIndex >= 0 ? activeIndex : null,
+      collectionPaths,
       windowState,
     }).catch(() => { /* Tab persistence failure is non-critical */ });
   },
@@ -984,9 +992,9 @@ export const useTabStore = create<TabState>((set, get) => ({
   restoreTabs: async () => {
     try {
       const persisted = await loadPersistedState();
-      if (persisted.tabs.length === 0) return;
+      if (persisted.tabs.length === 0 && persisted.collectionPaths.length === 0) return;
 
-      const collectionPaths = new Set<string>();
+      const collectionPaths = new Set<string>(persisted.collectionPaths);
       const seenPaths = new Set<string>();
 
       for (const pt of persisted.tabs) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -578,6 +578,7 @@ export interface WindowState {
 export interface PersistedState {
   tabs: PersistedTab[];
   activeTabIndex: number | null;
+  collectionPaths: string[];
   windowState?: WindowState;
 }
 


### PR DESCRIPTION
## Summary
- persist opened collection folder paths separately from restored tabs
- restore sidebar collections even when the previous session had no open request tabs
- add regression coverage for legacy state.json files and collection path round-tripping

## Testing
- cargo test collection_paths
- corepack pnpm --filter @apiark/desktop build
- corepack pnpm --filter @apiark/desktop lint (existing warnings only)

Fixes #34