### PR TITLE
feat(tabs): add open requests dropdown

### DIFF
--- a/apps/desktop/src/__tests__/stores/tab-store.test.ts
+++ b/apps/desktop/src/__tests__/stores/tab-store.test.ts
@@ -21,6 +21,18 @@ vi.mock("@/stores/console-store", () => ({
   useConsoleStore: { getState: () => ({ log: vi.fn() }) },
 }));
 
+vi.mock("@/stores/collection-store", () => ({
+  useCollectionStore: {
+    getState: () => ({ openCollection: vi.fn().mockResolvedValue(undefined) }),
+  },
+}));
+
+vi.mock("@/stores/toast-store", () => ({
+  useToastStore: {
+    getState: () => ({ showWarning: vi.fn(), showError: vi.fn() }),
+  },
+}));
+
 import { useTabStore } from "@/stores/tab-store";
 
 describe("Tab Store", () => {
@@ -178,5 +190,32 @@ describe("Tab Store", () => {
     useTabStore.getState().closeAllTabs();
     expect(useTabStore.getState().tabs).toHaveLength(0);
     expect(useTabStore.getState().activeTabId).toBeNull();
+  });
+
+  it("does not duplicate tabs when restoreTabs runs twice (StrictMode double-mount)", async () => {
+    const api = await import("@/lib/tauri-api");
+    vi.mocked(api.loadPersistedState).mockResolvedValue({
+      tabs: [
+        { filePath: "/col/req1.yaml", collectionPath: "/col" },
+        { filePath: "/col/req2.yaml", collectionPath: "/col" },
+      ],
+      activeTabIndex: 0,
+      collections: [],
+    } as never);
+    vi.mocked(api.readRequestFile).mockImplementation(
+      async (filePath: string) =>
+        ({ name: filePath, method: "GET", url: "https://example.com", headers: {}, params: {} }) as never,
+    );
+
+    // StrictMode mounts the effect twice without cleanup, so restoreTabs
+    // runs concurrently. It must stay idempotent and not append duplicates.
+    await Promise.all([
+      useTabStore.getState().restoreTabs(),
+      useTabStore.getState().restoreTabs(),
+    ]);
+
+    const filePaths = useTabStore.getState().tabs.map((t) => t.filePath).sort();
+    expect(useTabStore.getState().tabs).toHaveLength(2);
+    expect(filePaths).toEqual(["/col/req1.yaml", "/col/req2.yaml"]);
   });
 });

--- a/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
+++ b/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
@@ -8,21 +8,32 @@ import { TabBadge } from "./tab-badge";
 function OpenRequestRow({
   tab,
   isActive,
+  isHighlighted,
   onActivate,
   onClose,
 }: {
   tab: Tab;
   isActive: boolean;
+  isHighlighted: boolean;
   onActivate: () => void;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isHighlighted) {
+      rowRef.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [isHighlighted]);
+
   return (
     <div
+      ref={rowRef}
       onClick={onActivate}
       title={tab.name}
       className={`group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm ${
-        isActive
+        isActive || isHighlighted
           ? "bg-[var(--color-accent-glow)] text-[var(--color-text-primary)]"
           : "text-[var(--color-text-secondary)] hover:bg-[var(--color-accent-glow)]/50"
       }`}
@@ -50,6 +61,7 @@ export function OpenRequestsDropdown() {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [highlightIndex, setHighlightIndex] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const { tabs, activeTabId, setActiveTab, closeTab } = useTabStore();
@@ -61,20 +73,14 @@ export function OpenRequestsDropdown() {
         setOpen(false);
       }
     };
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
     document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
+    return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
   useEffect(() => {
     if (open) {
       setSearch("");
+      setHighlightIndex(0);
       requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [open]);
@@ -92,10 +98,43 @@ export function OpenRequestsDropdown() {
 
   const pinned = filtered.filter((t) => t.pinned);
   const unpinned = filtered.filter((t) => !t.pinned);
+  const ordered = [...pinned, ...unpinned];
+
+  // Clamp highlight when the underlying list shrinks (e.g. closing a tab or filtering).
+  useEffect(() => {
+    if (highlightIndex >= ordered.length) {
+      setHighlightIndex(Math.max(0, ordered.length - 1));
+    }
+  }, [ordered.length, highlightIndex]);
 
   const activate = (id: string) => {
     setActiveTab(id);
     setOpen(false);
+  };
+
+  const handlePopoverKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (ordered.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightIndex((i) => Math.min(i + 1, ordered.length - 1));
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightIndex((i) => Math.max(i - 1, 0));
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const target = ordered[highlightIndex];
+      if (target) activate(target.id);
+    }
   };
 
   return (
@@ -113,13 +152,19 @@ export function OpenRequestsDropdown() {
         </span>
       </button>
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-2 flex w-80 flex-col overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-elevated)] shadow-xl">
+        <div
+          onKeyDown={handlePopoverKeyDown}
+          className="absolute right-0 top-full z-50 mt-2 flex w-80 flex-col overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-elevated)] shadow-xl"
+        >
           <div className="border-b border-[var(--color-border)] p-2">
             <input
               ref={inputRef}
               type="text"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setHighlightIndex(0);
+              }}
               placeholder={t("tabs.searchOpenRequests")}
               aria-label={t("tabs.searchOpenRequests")}
               className="w-full rounded-md bg-[var(--color-surface)] px-2.5 py-1.5 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
@@ -132,11 +177,12 @@ export function OpenRequestsDropdown() {
               </div>
             ) : (
               <>
-                {pinned.map((tab) => (
+                {pinned.map((tab, i) => (
                   <OpenRequestRow
                     key={tab.id}
                     tab={tab}
                     isActive={tab.id === activeTabId}
+                    isHighlighted={i === highlightIndex}
                     onActivate={() => activate(tab.id)}
                     onClose={() => closeTab(tab.id)}
                   />
@@ -144,15 +190,19 @@ export function OpenRequestsDropdown() {
                 {pinned.length > 0 && unpinned.length > 0 && (
                   <div className="my-1 border-t border-[var(--color-border)]" />
                 )}
-                {unpinned.map((tab) => (
-                  <OpenRequestRow
-                    key={tab.id}
-                    tab={tab}
-                    isActive={tab.id === activeTabId}
-                    onActivate={() => activate(tab.id)}
-                    onClose={() => closeTab(tab.id)}
-                  />
-                ))}
+                {unpinned.map((tab, i) => {
+                  const overallIndex = pinned.length + i;
+                  return (
+                    <OpenRequestRow
+                      key={tab.id}
+                      tab={tab}
+                      isActive={tab.id === activeTabId}
+                      isHighlighted={overallIndex === highlightIndex}
+                      onActivate={() => activate(tab.id)}
+                      onClose={() => closeTab(tab.id)}
+                    />
+                  );
+                })}
               </>
             )}
           </div>

--- a/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
+++ b/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next";
+import { List } from "lucide-react";
+import { useTabStore } from "@/stores/tab-store";
+
+export function OpenRequestsDropdown() {
+  const { t } = useTranslation();
+  const tabs = useTabStore((s) => s.tabs);
+
+  return (
+    <div className="relative flex items-center">
+      <button
+        className="ml-1 flex shrink-0 items-center gap-1.5 rounded-lg bg-[var(--color-elevated)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-border)] hover:text-[var(--color-text-primary)]"
+        title={t("tabs.openRequests")}
+        aria-label={t("tabs.openRequests")}
+      >
+        <List className="h-4 w-4" />
+        <span className="rounded-md bg-[var(--color-surface)] px-1.5 text-[10px] tabular-nums">
+          {tabs.length}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
+++ b/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
@@ -1,14 +1,74 @@
+import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { List } from "lucide-react";
+import type { Tab } from "@apiark/types";
 import { useTabStore } from "@/stores/tab-store";
+import { TabBadge } from "./tab-badge";
+
+function OpenRequestRow({
+  tab,
+  isActive,
+  onActivate,
+}: {
+  tab: Tab;
+  isActive: boolean;
+  onActivate: () => void;
+}) {
+  return (
+    <div
+      onClick={onActivate}
+      title={tab.name}
+      className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm ${
+        isActive
+          ? "bg-[var(--color-accent-glow)] text-[var(--color-text-primary)]"
+          : "text-[var(--color-text-secondary)] hover:bg-[var(--color-accent-glow)]/50"
+      }`}
+    >
+      <TabBadge tab={tab} />
+      <span className="min-w-0 flex-1 truncate">{tab.name}</span>
+      {tab.isDirty && (
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-accent)]" />
+      )}
+    </div>
+  );
+}
 
 export function OpenRequestsDropdown() {
   const { t } = useTranslation();
-  const tabs = useTabStore((s) => s.tabs);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { tabs, activeTabId, setActiveTab } = useTabStore();
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const pinned = tabs.filter((t) => t.pinned);
+  const unpinned = tabs.filter((t) => !t.pinned);
+
+  const activate = (id: string) => {
+    setActiveTab(id);
+    setOpen(false);
+  };
 
   return (
-    <div className="relative flex items-center">
+    <div ref={ref} className="relative flex items-center">
       <button
+        onClick={() => setOpen((o) => !o)}
         className="ml-1 flex shrink-0 items-center gap-1.5 rounded-lg bg-[var(--color-elevated)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-border)] hover:text-[var(--color-text-primary)]"
         title={t("tabs.openRequests")}
         aria-label={t("tabs.openRequests")}
@@ -18,6 +78,31 @@ export function OpenRequestsDropdown() {
           {tabs.length}
         </span>
       </button>
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-2 flex w-80 flex-col overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-elevated)] shadow-xl">
+          <div className="max-h-[60vh] overflow-y-auto p-1">
+            {pinned.map((tab) => (
+              <OpenRequestRow
+                key={tab.id}
+                tab={tab}
+                isActive={tab.id === activeTabId}
+                onActivate={() => activate(tab.id)}
+              />
+            ))}
+            {pinned.length > 0 && unpinned.length > 0 && (
+              <div className="my-1 border-t border-[var(--color-border)]" />
+            )}
+            {unpinned.map((tab) => (
+              <OpenRequestRow
+                key={tab.id}
+                tab={tab}
+                isActive={tab.id === activeTabId}
+                onActivate={() => activate(tab.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
+++ b/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { List } from "lucide-react";
 import type { Tab } from "@apiark/types";
@@ -36,7 +36,9 @@ function OpenRequestRow({
 export function OpenRequestsDropdown() {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
   const ref = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { tabs, activeTabId, setActiveTab } = useTabStore();
 
   useEffect(() => {
@@ -57,8 +59,27 @@ export function OpenRequestsDropdown() {
     };
   }, [open]);
 
-  const pinned = tabs.filter((t) => t.pinned);
-  const unpinned = tabs.filter((t) => !t.pinned);
+  // Reset search and focus the input each time the popover opens.
+  useEffect(() => {
+    if (open) {
+      setSearch("");
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const query = search.trim().toLowerCase();
+
+  const filtered = useMemo(() => {
+    if (!query) return tabs;
+    return tabs.filter((tab) =>
+      tab.name.toLowerCase().includes(query) ||
+      tab.method.toLowerCase().includes(query) ||
+      tab.url.toLowerCase().includes(query),
+    );
+  }, [tabs, query]);
+
+  const pinned = filtered.filter((t) => t.pinned);
+  const unpinned = filtered.filter((t) => !t.pinned);
 
   const activate = (id: string) => {
     setActiveTab(id);
@@ -72,6 +93,7 @@ export function OpenRequestsDropdown() {
         className="ml-1 flex shrink-0 items-center gap-1.5 rounded-lg bg-[var(--color-elevated)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-border)] hover:text-[var(--color-text-primary)]"
         title={t("tabs.openRequests")}
         aria-label={t("tabs.openRequests")}
+        aria-expanded={open}
       >
         <List className="h-4 w-4" />
         <span className="rounded-md bg-[var(--color-surface)] px-1.5 text-[10px] tabular-nums">
@@ -80,26 +102,45 @@ export function OpenRequestsDropdown() {
       </button>
       {open && (
         <div className="absolute right-0 top-full z-50 mt-2 flex w-80 flex-col overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-elevated)] shadow-xl">
+          <div className="border-b border-[var(--color-border)] p-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t("tabs.searchOpenRequests")}
+              aria-label={t("tabs.searchOpenRequests")}
+              className="w-full rounded-md bg-[var(--color-surface)] px-2.5 py-1.5 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+            />
+          </div>
           <div className="max-h-[60vh] overflow-y-auto p-1">
-            {pinned.map((tab) => (
-              <OpenRequestRow
-                key={tab.id}
-                tab={tab}
-                isActive={tab.id === activeTabId}
-                onActivate={() => activate(tab.id)}
-              />
-            ))}
-            {pinned.length > 0 && unpinned.length > 0 && (
-              <div className="my-1 border-t border-[var(--color-border)]" />
+            {filtered.length === 0 ? (
+              <div className="px-3 py-6 text-center text-sm text-[var(--color-text-muted)]">
+                {t("tabs.noMatchingRequests")}
+              </div>
+            ) : (
+              <>
+                {pinned.map((tab) => (
+                  <OpenRequestRow
+                    key={tab.id}
+                    tab={tab}
+                    isActive={tab.id === activeTabId}
+                    onActivate={() => activate(tab.id)}
+                  />
+                ))}
+                {pinned.length > 0 && unpinned.length > 0 && (
+                  <div className="my-1 border-t border-[var(--color-border)]" />
+                )}
+                {unpinned.map((tab) => (
+                  <OpenRequestRow
+                    key={tab.id}
+                    tab={tab}
+                    isActive={tab.id === activeTabId}
+                    onActivate={() => activate(tab.id)}
+                  />
+                ))}
+              </>
             )}
-            {unpinned.map((tab) => (
-              <OpenRequestRow
-                key={tab.id}
-                tab={tab}
-                isActive={tab.id === activeTabId}
-                onActivate={() => activate(tab.id)}
-              />
-            ))}
           </div>
         </div>
       )}

--- a/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
+++ b/apps/desktop/src/components/tabs/open-requests-dropdown.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { List } from "lucide-react";
+import { List, X } from "lucide-react";
 import type { Tab } from "@apiark/types";
 import { useTabStore } from "@/stores/tab-store";
 import { TabBadge } from "./tab-badge";
@@ -9,16 +9,19 @@ function OpenRequestRow({
   tab,
   isActive,
   onActivate,
+  onClose,
 }: {
   tab: Tab;
   isActive: boolean;
   onActivate: () => void;
+  onClose: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div
       onClick={onActivate}
       title={tab.name}
-      className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm ${
+      className={`group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm ${
         isActive
           ? "bg-[var(--color-accent-glow)] text-[var(--color-text-primary)]"
           : "text-[var(--color-text-secondary)] hover:bg-[var(--color-accent-glow)]/50"
@@ -29,6 +32,16 @@ function OpenRequestRow({
       {tab.isDirty && (
         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-accent)]" />
       )}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        className="rounded p-0.5 opacity-0 transition-opacity hover:bg-[var(--color-border)] group-hover:opacity-100"
+        aria-label={`${t("tabs.close")} ${tab.name}`}
+      >
+        <X className="h-3 w-3" />
+      </button>
     </div>
   );
 }
@@ -39,7 +52,7 @@ export function OpenRequestsDropdown() {
   const [search, setSearch] = useState("");
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const { tabs, activeTabId, setActiveTab } = useTabStore();
+  const { tabs, activeTabId, setActiveTab, closeTab } = useTabStore();
 
   useEffect(() => {
     if (!open) return;
@@ -59,7 +72,6 @@ export function OpenRequestsDropdown() {
     };
   }, [open]);
 
-  // Reset search and focus the input each time the popover opens.
   useEffect(() => {
     if (open) {
       setSearch("");
@@ -126,6 +138,7 @@ export function OpenRequestsDropdown() {
                     tab={tab}
                     isActive={tab.id === activeTabId}
                     onActivate={() => activate(tab.id)}
+                    onClose={() => closeTab(tab.id)}
                   />
                 ))}
                 {pinned.length > 0 && unpinned.length > 0 && (
@@ -137,6 +150,7 @@ export function OpenRequestsDropdown() {
                     tab={tab}
                     isActive={tab.id === activeTabId}
                     onActivate={() => activate(tab.id)}
+                    onClose={() => closeTab(tab.id)}
                   />
                 ))}
               </>

--- a/apps/desktop/src/components/tabs/tab-badge.tsx
+++ b/apps/desktop/src/components/tabs/tab-badge.tsx
@@ -1,0 +1,37 @@
+import type { HttpMethod, Tab } from "@apiark/types";
+
+const METHOD_COLORS: Record<HttpMethod, string> = {
+  GET: "bg-emerald-500/15 text-emerald-400",
+  POST: "bg-amber-500/15 text-amber-400",
+  PUT: "bg-blue-500/15 text-blue-400",
+  PATCH: "bg-purple-500/15 text-purple-400",
+  DELETE: "bg-red-500/15 text-red-400",
+  HEAD: "bg-cyan-500/15 text-cyan-400",
+  OPTIONS: "bg-gray-500/15 text-gray-400",
+};
+
+export function TabBadge({ tab }: { tab: Tab }) {
+  const badges: Record<string, { bg: string; label: string }> = {
+    graphql: { bg: "bg-violet-500/15 text-violet-400", label: "GQL" },
+    websocket: { bg: "bg-cyan-500/15 text-cyan-400", label: "WS" },
+    sse: { bg: "bg-orange-500/15 text-orange-400", label: "SSE" },
+    grpc: { bg: "bg-emerald-500/15 text-emerald-400", label: "gRPC" },
+    mqtt: { bg: "bg-purple-500/15 text-purple-400", label: "MQTT" },
+    socketio: { bg: "bg-pink-500/15 text-pink-400", label: "SIO" },
+  };
+
+  if (tab.protocol !== "http") {
+    const badge = badges[tab.protocol];
+    return (
+      <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${badge?.bg ?? ""}`}>
+        {badge?.label ?? tab.protocol}
+      </span>
+    );
+  }
+
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${METHOD_COLORS[tab.method]}`}>
+      {tab.method}
+    </span>
+  );
+}

--- a/apps/desktop/src/components/tabs/tab-bar.tsx
+++ b/apps/desktop/src/components/tabs/tab-bar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { Tab } from "@apiark/types";
 import { useTabStore } from "@/stores/tab-store";
 import { TabBadge } from "./tab-badge";
+import { OpenRequestsDropdown } from "./open-requests-dropdown";
 import { Plus, X, Globe, Zap, Radio, ChevronDown, Pin, Save, Terminal } from "lucide-react";
 import {
   DndContext,
@@ -303,6 +304,7 @@ export function TabBar() {
             {t("common.save")}
           </button>
         )}
+        <OpenRequestsDropdown />
         <NewTabDropdown />
       </div>
     </div>

--- a/apps/desktop/src/components/tabs/tab-bar.tsx
+++ b/apps/desktop/src/components/tabs/tab-bar.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import type { HttpMethod, Tab } from "@apiark/types";
+import type { Tab } from "@apiark/types";
 import { useTabStore } from "@/stores/tab-store";
+import { TabBadge } from "./tab-badge";
 import { Plus, X, Globe, Zap, Radio, ChevronDown, Pin, Save, Terminal } from "lucide-react";
 import {
   DndContext,
@@ -17,42 +18,6 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-
-const METHOD_COLORS: Record<HttpMethod, string> = {
-  GET: "bg-emerald-500/15 text-emerald-400",
-  POST: "bg-amber-500/15 text-amber-400",
-  PUT: "bg-blue-500/15 text-blue-400",
-  PATCH: "bg-purple-500/15 text-purple-400",
-  DELETE: "bg-red-500/15 text-red-400",
-  HEAD: "bg-cyan-500/15 text-cyan-400",
-  OPTIONS: "bg-gray-500/15 text-gray-400",
-};
-
-function TabBadge({ tab }: { tab: Tab }) {
-  const badges: Record<string, { bg: string; label: string }> = {
-    graphql: { bg: "bg-violet-500/15 text-violet-400", label: "GQL" },
-    websocket: { bg: "bg-cyan-500/15 text-cyan-400", label: "WS" },
-    sse: { bg: "bg-orange-500/15 text-orange-400", label: "SSE" },
-    grpc: { bg: "bg-emerald-500/15 text-emerald-400", label: "gRPC" },
-    mqtt: { bg: "bg-purple-500/15 text-purple-400", label: "MQTT" },
-    socketio: { bg: "bg-pink-500/15 text-pink-400", label: "SIO" },
-  };
-
-  if (tab.protocol !== "http") {
-    const badge = badges[tab.protocol];
-    return (
-      <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${badge?.bg ?? ""}`}>
-        {badge?.label ?? tab.protocol}
-      </span>
-    );
-  }
-
-  return (
-    <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${METHOD_COLORS[tab.method]}`}>
-      {tab.method}
-    </span>
-  );
-}
 
 function SortableTab({
   tab,

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -70,7 +70,9 @@
     "moveToNewWindow": "Move to New Window",
     "httpRequest": "HTTP Request",
     "importCurl": "Import cURL",
-    "openRequests": "Open Requests"
+    "openRequests": "Open Requests",
+    "searchOpenRequests": "Search open requests…",
+    "noMatchingRequests": "No matching requests"
   },
   "request": {
     "send": "Send",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -69,7 +69,8 @@
     "duplicateTab": "Duplicate Tab",
     "moveToNewWindow": "Move to New Window",
     "httpRequest": "HTTP Request",
-    "importCurl": "Import cURL"
+    "importCurl": "Import cURL",
+    "openRequests": "Open Requests"
   },
   "request": {
     "send": "Send",

--- a/apps/desktop/src/locales/es.json
+++ b/apps/desktop/src/locales/es.json
@@ -70,7 +70,9 @@
     "moveToNewWindow": "Mover a Nueva Ventana",
     "httpRequest": "Solicitud HTTP",
     "importCurl": "Importar cURL",
-    "openRequests": "Solicitudes abiertas"
+    "openRequests": "Solicitudes abiertas",
+    "searchOpenRequests": "Buscar solicitudes abiertas…",
+    "noMatchingRequests": "No hay solicitudes coincidentes"
   },
   "request": {
     "send": "Enviar",

--- a/apps/desktop/src/locales/es.json
+++ b/apps/desktop/src/locales/es.json
@@ -69,7 +69,8 @@
     "duplicateTab": "Duplicar Pestaña",
     "moveToNewWindow": "Mover a Nueva Ventana",
     "httpRequest": "Solicitud HTTP",
-    "importCurl": "Importar cURL"
+    "importCurl": "Importar cURL",
+    "openRequests": "Solicitudes abiertas"
   },
   "request": {
     "send": "Enviar",

--- a/apps/desktop/src/stores/tab-store.ts
+++ b/apps/desktop/src/stores/tab-store.ts
@@ -1100,10 +1100,16 @@ export const useTabStore = create<TabState>((set, get) => ({
         try {
           const file = await readRequestFile(pt.filePath);
           const tab = requestFileToTab(file, pt.filePath, pt.collectionPath);
-          set((state) => ({
-            tabs: [...state.tabs, tab],
-            activeTabId: state.activeTabId ?? tab.id,
-          }));
+          set((state) => {
+            // Guard against a concurrent restore (e.g. React StrictMode mounts
+            // the effect twice). seenPaths only dedups within a single call, so
+            // also skip paths already present in the store.
+            if (state.tabs.some((t) => t.filePath === pt.filePath)) return state;
+            return {
+              tabs: [...state.tabs, tab],
+              activeTabId: state.activeTabId ?? tab.id,
+            };
+          });
           if (pt.collectionPath) collectionPaths.add(pt.collectionPath);
         } catch {
           // File may have been deleted, skip it


### PR DESCRIPTION
## Summary
- New "Open Requests" dropdown in the tab bar's trailing controls — a vertical, searchable list of every open request tab. Lets you find and switch to a tab by name/method/URL when horizontal scrolling and truncated names get in the way.
- Supports search (name / method / URL substring), inline close (X) per row, keyboard navigation (↑ / ↓ / Enter / Esc), click-outside to dismiss, and active-row + highlight states.
- Pinned tabs grouped first with a divider, mirroring tab bar order.
- Refactors `TabBadge` out of `tab-bar.tsx` into its own file so the dropdown can reuse it. No behavior change in the existing tab bar.

## Screenshot

![Open requests dropdown](https://github.com/diegoQuinas/apiark/releases/download/pr-79-screenshots/open-requests-dropdown.png)

## i18n
English and Spanish translations included for the three new strings (`tabs.openRequests`, `tabs.searchOpenRequests`, `tabs.noMatchingRequests`). The other seven locales (ar, de, fr, ja, ko, pt, zh) fall back to English via i18next — translation contributions welcome.

## Test plan
- [ ] Open ~10 tabs of mixed protocols (HTTP / GraphQL / WebSocket / SSE / gRPC); pin two; make one dirty.
- [ ] Click the list-icon trigger → popover opens; pinned section appears first with a divider, then unpinned.
- [ ] Active tab highlighted; dirty dot visible.
- [ ] Click a row → switches active tab, closes popover.
- [ ] Type in the search box → list filters by name / method / URL; clear → all return.
- [ ] No matches → empty state ("No matching requests").
- [ ] Hover a row → X reveals; click X → tab closes; popover stays open.
- [ ] Close the active tab via inline X → store picks a new active; dropdown reflects it.
- [ ] ↑ / ↓ move highlight; Enter activates; Esc closes; click outside closes.
- [ ] Long names truncate with full name on hover via \`title\`.
- [ ] Switch app locale to Spanish → trigger tooltip, search placeholder, empty state are translated.
- [ ] CJK IME composition (e.g. Japanese) works inside the search box without Enter being intercepted by the dropdown's nav handler.

Closes #78