### PR TITLE
fix(curl): parse -b/--cookie flag as Cookie header

### DIFF
--- a/apps/desktop/src-tauri/src/http/curl.rs
+++ b/apps/desktop/src-tauri/src/http/curl.rs
@@ -64,6 +64,12 @@ pub fn parse_curl(input: &str) -> Result<ParsedCurlRequest, String> {
             "-L" | "--location" => {
                 follow_redirects = true;
             }
+            "-b" | "--cookie" => {
+                i += 1;
+                if let Some(cookie_val) = tokens.get(i) {
+                    headers.insert("Cookie".to_string(), cookie_val.clone());
+                }
+            }
             "--compressed" | "-s" | "--silent" | "-S" | "--show-error" | "-v" | "--verbose" => {
                 // Ignored flags
             }

--- a/apps/desktop/src-tauri/src/http/curl.rs
+++ b/apps/desktop/src-tauri/src/http/curl.rs
@@ -237,4 +237,28 @@ mod tests {
         let result = parse_curl("curl -k https://example.com").unwrap();
         assert!(!result.verify_ssl);
     }
+
+    #[test]
+    fn test_cookie_short_flag() {
+        let result = parse_curl(
+            "curl https://example.com -b 'session=abc123; token=xyz'",
+        )
+        .unwrap();
+        assert_eq!(
+            result.headers.get("Cookie").map(String::as_str),
+            Some("session=abc123; token=xyz"),
+        );
+    }
+
+    #[test]
+    fn test_cookie_long_flag() {
+        let result = parse_curl(
+            "curl https://example.com --cookie 'session=abc123'",
+        )
+        .unwrap();
+        assert_eq!(
+            result.headers.get("Cookie").map(String::as_str),
+            Some("session=abc123"),
+        );
+    }
 }


### PR DESCRIPTION
## Problem

When importing a curl command that uses `-b` or `--cookie`, the flag and its value were silently dropped. No error was shown. Closes #66.

## Root Cause

In `parse_curl()` (`apps/desktop/src-tauri/src/http/curl.rs`), the `-b`/`--cookie` flag hit the `_ =>` catch-all, which skipped the flag but left the cookie value to be mishandled by the next loop iteration.

## Fix

Added a match arm that consumes the next token and inserts it as a `Cookie` header — consistent with how `-H`, `-d`, and `-u` are handled.

## Testing

Added two unit tests: one for `-b` (short form) and one for `--cookie` (long form). All 6 curl unit tests pass.

```bash
cd apps/desktop/src-tauri && cargo test http::curl
# test result: ok. 6 passed; 0 failed
```