### PR TITLE
feat: make collections sidebar resizable by dragging its edge

### DIFF
--- a/apps/desktop/src/__tests__/lib/sidebar-width.test.ts
+++ b/apps/desktop/src/__tests__/lib/sidebar-width.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_DEFAULT_WIDTH,
+  clampSidebarWidth,
+} from "@/lib/sidebar-width";
+
+describe("clampSidebarWidth", () => {
+  it("returns the value unchanged when within bounds", () => {
+    expect(clampSidebarWidth(360)).toBe(360);
+  });
+
+  it("clamps values below the minimum up to the minimum", () => {
+    expect(clampSidebarWidth(50)).toBe(SIDEBAR_MIN_WIDTH);
+  });
+
+  it("clamps values above the maximum down to the maximum", () => {
+    expect(clampSidebarWidth(5000)).toBe(SIDEBAR_MAX_WIDTH);
+  });
+
+  it("allows widening beyond the old 400px cap so request names are no longer truncated", () => {
+    // Regression guard for issue #63: the sidebar must be expandable past 400px.
+    expect(SIDEBAR_MAX_WIDTH).toBeGreaterThan(400);
+    expect(clampSidebarWidth(600)).toBe(600);
+  });
+
+  it("rounds fractional widths produced by drag deltas", () => {
+    expect(clampSidebarWidth(320.7)).toBe(321);
+  });
+
+  it("exposes a default that sits within the allowed range", () => {
+    expect(SIDEBAR_DEFAULT_WIDTH).toBeGreaterThanOrEqual(SIDEBAR_MIN_WIDTH);
+    expect(SIDEBAR_DEFAULT_WIDTH).toBeLessThanOrEqual(SIDEBAR_MAX_WIDTH);
+  });
+});

--- a/apps/desktop/src/components/layout/side-panel.tsx
+++ b/apps/desktop/src/components/layout/side-panel.tsx
@@ -1,5 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_DEFAULT_WIDTH,
+  clampSidebarWidth,
+} from "@/lib/sidebar-width";
 import { useCollectionStore } from "@/stores/collection-store";
 import { CollectionTree } from "@/components/collection/collection-tree";
 import { EnvironmentSelector } from "@/components/environment/environment-selector";
@@ -47,12 +53,83 @@ export function SidePanel({
   };
 
   const sidebarWidth = useSettingsStore((s) => s.settings.sidebarWidth);
+  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      const startLeft = panel.getBoundingClientRect().left;
+      let finalWidth: number | null = null;
+
+      const onMouseMove = (ev: MouseEvent) => {
+        finalWidth = clampSidebarWidth(ev.clientX - startLeft);
+        // Direct DOM mutation during drag — no React re-render, instant feedback.
+        panel.style.width = `${finalWidth}px`;
+      };
+
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        // Only persist when an actual drag happened (skip a bare click).
+        if (finalWidth !== null) void updateSettings({ sidebarWidth: finalWidth });
+      };
+
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [updateSettings],
+  );
+
+  const handleResizeKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const STEP = 16;
+      let next: number | null = null;
+      if (e.key === "ArrowLeft") next = sidebarWidth - STEP;
+      else if (e.key === "ArrowRight") next = sidebarWidth + STEP;
+      else if (e.key === "Home") next = SIDEBAR_MIN_WIDTH;
+      else if (e.key === "End") next = SIDEBAR_MAX_WIDTH;
+      if (next === null) return;
+      e.preventDefault();
+      void updateSettings({ sidebarWidth: clampSidebarWidth(next) });
+    },
+    [sidebarWidth, updateSettings],
+  );
 
   return (
     <div
-      className="flex shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)]"
+      ref={panelRef}
+      className="relative flex shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)]"
       style={{ width: `${sidebarWidth}px` }}
     >
+      {/* Drag-to-resize handle on the right edge */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={t("sidebar.resize")}
+        aria-valuenow={sidebarWidth}
+        aria-valuemin={SIDEBAR_MIN_WIDTH}
+        aria-valuemax={SIDEBAR_MAX_WIDTH}
+        tabIndex={0}
+        title={t("sidebar.resize")}
+        onMouseDown={handleResizeStart}
+        onKeyDown={handleResizeKeyDown}
+        onDoubleClick={() => void updateSettings({ sidebarWidth: SIDEBAR_DEFAULT_WIDTH })}
+        className="group absolute inset-y-0 right-0 z-10 w-1.5 -mr-0.5 cursor-col-resize outline-none"
+      >
+        {/* Visible line, highlighted on hover/drag/focus */}
+        <div className="absolute inset-y-0 left-[2px] w-0.5 rounded-full bg-transparent transition-colors group-hover:bg-[var(--color-accent)] group-focus:bg-[var(--color-accent)] group-active:bg-[var(--color-accent)]" />
+        {/* Invisible hit target, biased outward into the gutter to avoid the content scrollbar */}
+        <div className="absolute inset-y-0 left-0 -right-2" />
+      </div>
+
       {/* Panel header */}
       <div className="flex h-11 shrink-0 items-center px-4">
         <span className="text-sm font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">

--- a/apps/desktop/src/components/settings/settings-dialog.tsx
+++ b/apps/desktop/src/components/settings/settings-dialog.tsx
@@ -4,6 +4,7 @@ import { X, FolderOpen, Download, Upload, RefreshCw, ExternalLink } from "lucide
 import { useTranslation } from "react-i18next";
 import { LANGUAGES } from "@/lib/i18n";
 import { useSettingsStore } from "@/stores/settings-store";
+import { SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH } from "@/lib/sidebar-width";
 import {
   useShortcutsStore,
   SHORTCUT_ACTIONS,
@@ -140,8 +141,8 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 </label>
                 <input
                   type="range"
-                  min={180}
-                  max={400}
+                  min={SIDEBAR_MIN_WIDTH}
+                  max={SIDEBAR_MAX_WIDTH}
                   step={4}
                   value={settings.sidebarWidth}
                   onChange={(e) => update({ sidebarWidth: Number(e.target.value) })}

--- a/apps/desktop/src/lib/sidebar-width.ts
+++ b/apps/desktop/src/lib/sidebar-width.ts
@@ -1,0 +1,9 @@
+/** Bounds for the collections side panel width, shared by the drag handle and the settings slider. */
+export const SIDEBAR_MIN_WIDTH = 180;
+export const SIDEBAR_MAX_WIDTH = 700;
+export const SIDEBAR_DEFAULT_WIDTH = 400;
+
+/** Clamp a (possibly fractional) pixel width to the allowed sidebar range, rounded to a whole pixel. */
+export function clampSidebarWidth(width: number): number {
+  return Math.round(Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width)));
+}

--- a/apps/desktop/src/locales/ar.json
+++ b/apps/desktop/src/locales/ar.json
@@ -15,6 +15,7 @@
     "ok": "موافق"
   },
   "sidebar": {
+    "resize": "اسحب لتغيير حجم الشريط الجانبي",
     "collections": "المجموعات",
     "history": "السجل",
     "environments": "البيئات",

--- a/apps/desktop/src/locales/de.json
+++ b/apps/desktop/src/locales/de.json
@@ -15,6 +15,7 @@
     "ok": "OK"
   },
   "sidebar": {
+    "resize": "Ziehen, um die Seitenleiste anzupassen",
     "collections": "Sammlungen",
     "history": "Verlauf",
     "environments": "Umgebungen",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -15,6 +15,7 @@
     "ok": "OK"
   },
   "sidebar": {
+    "resize": "Drag to resize sidebar",
     "collections": "Collections",
     "history": "History",
     "environments": "Environments",

--- a/apps/desktop/src/locales/es.json
+++ b/apps/desktop/src/locales/es.json
@@ -15,6 +15,7 @@
     "ok": "OK"
   },
   "sidebar": {
+    "resize": "Arrastrá para redimensionar la barra lateral",
     "collections": "Colecciones",
     "history": "Historial",
     "environments": "Entornos",

--- a/apps/desktop/src/locales/fr.json
+++ b/apps/desktop/src/locales/fr.json
@@ -15,6 +15,7 @@
     "ok": "OK"
   },
   "sidebar": {
+    "resize": "Glisser pour redimensionner la barre latérale",
     "collections": "Collections",
     "history": "Historique",
     "environments": "Environnements",

--- a/apps/desktop/src/locales/ja.json
+++ b/apps/desktop/src/locales/ja.json
@@ -15,6 +15,7 @@
     "ok": "OK"
   },
   "sidebar": {
+    "resize": "ドラッグしてサイドバーのサイズを変更",
     "collections": "コレクション",
     "history": "履歴",
     "environments": "環境",

--- a/apps/desktop/src/locales/ko.json
+++ b/apps/desktop/src/locales/ko.json
@@ -15,6 +15,7 @@
     "ok": "확인"
   },
   "sidebar": {
+    "resize": "드래그하여 사이드바 크기 조절",
     "collections": "컬렉션",
     "history": "기록",
     "environments": "환경",

--- a/apps/desktop/src/locales/pt.json
+++ b/apps/desktop/src/locales/pt.json
@@ -15,6 +15,7 @@
     "ok": "OK"
   },
   "sidebar": {
+    "resize": "Arraste para redimensionar a barra lateral",
     "collections": "Coleções",
     "history": "Histórico",
     "environments": "Ambientes",

--- a/apps/desktop/src/locales/zh.json
+++ b/apps/desktop/src/locales/zh.json
@@ -15,6 +15,7 @@
     "ok": "确定"
   },
   "sidebar": {
+    "resize": "拖动以调整侧边栏宽度",
     "collections": "集合",
     "history": "历史记录",
     "environments": "环境",


### PR DESCRIPTION
Closes #63

## Problem

The left collections panel had a fixed width whose only control was a settings slider capped at **400px** — which is also its default. So the panel was already pinned at its maximum, long request names stayed truncated, and there was no way to drag the panel wider.

## Fix

- Add a **drag-to-resize handle** on the panel's right edge (direct DOM mutation during drag for smooth feedback, persisted to settings on mouse-up).
- **Keyboard accessible**: the handle is a focusable `separator` with `aria-valuenow/min/max`; ← → adjust width, Home/End jump to min/max.
- **Double-click** the handle to reset to the default width.
- Raise the maximum width cap from 400px to **700px** so names actually fit.
- Extract shared clamp bounds (`SIDEBAR_MIN_WIDTH` / `SIDEBAR_MAX_WIDTH`) into `lib/sidebar-width.ts`, reused by both the drag handle and the settings slider so they can never drift.
- Add the `sidebar.resize` label to all 10 locales.

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src/lib/sidebar-width.ts` | New: shared bounds + `clampSidebarWidth` helper |
| `apps/desktop/src/components/layout/side-panel.tsx` | Drag/keyboard resize handle on the right edge |
| `apps/desktop/src/components/settings/settings-dialog.tsx` | Slider uses the shared min/max (now up to 700px) |
| `apps/desktop/src/locales/*.json` | New `sidebar.resize` string (9 + en) |
| `apps/desktop/src/__tests__/lib/sidebar-width.test.ts` | Unit tests for the clamp logic |

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm -C apps/desktop exec tsc --noEmit` — passes
- [x] `pnpm -C apps/desktop test` — 32 passed (6 new for `clampSidebarWidth`)