### PR TITLE
fix(tabs): stop wiping persisted collections on startup (persist race)

### DIFF
--- a/apps/desktop/src/__tests__/stores/tab-store.test.ts
+++ b/apps/desktop/src/__tests__/stores/tab-store.test.ts
@@ -21,6 +21,21 @@ vi.mock("@/stores/console-store", () => ({
   useConsoleStore: { getState: () => ({ log: vi.fn() }) },
 }));
 
+vi.mock("@/stores/collection-store", () => ({
+  useCollectionStore: {
+    getState: () => ({
+      collections: [],
+      openCollection: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("@/stores/toast-store", () => ({
+  useToastStore: {
+    getState: () => ({ showWarning: vi.fn(), showError: vi.fn() }),
+  },
+}));
+
 import { useTabStore } from "@/stores/tab-store";
 
 describe("Tab Store", () => {
@@ -28,6 +43,7 @@ describe("Tab Store", () => {
     useTabStore.setState({
       tabs: [],
       activeTabId: null,
+      hydrated: false,
     });
   });
 
@@ -178,5 +194,34 @@ describe("Tab Store", () => {
     useTabStore.getState().closeAllTabs();
     expect(useTabStore.getState().tabs).toHaveLength(0);
     expect(useTabStore.getState().activeTabId).toBeNull();
+  });
+
+  it("does not persist before hydration, so an early startup persist cannot wipe collections", async () => {
+    const api = await import("@/lib/tauri-api");
+    vi.mocked(api.savePersistedState).mockClear();
+
+    // Startup: store not yet hydrated (restoreTabs hasn't loaded collections).
+    useTabStore.setState({ tabs: [], activeTabId: null, hydrated: false });
+
+    // The debounced persist effect fires before restore finishes...
+    useTabStore.getState().persistTabs();
+    // Flush the dynamic import + microtasks persistTabs would use to save.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // ...and must write nothing, otherwise it overwrites collections with [].
+    expect(api.savePersistedState).not.toHaveBeenCalled();
+  });
+
+  it("marks the store hydrated after restoreTabs completes", async () => {
+    const api = await import("@/lib/tauri-api");
+    vi.mocked(api.loadPersistedState).mockResolvedValue({
+      tabs: [],
+      activeTabIndex: null,
+      collections: ["/col"],
+    } as never);
+
+    expect(useTabStore.getState().hydrated).toBe(false);
+    await useTabStore.getState().restoreTabs();
+    expect(useTabStore.getState().hydrated).toBe(true);
   });
 });

--- a/apps/desktop/src/stores/tab-store.ts
+++ b/apps/desktop/src/stores/tab-store.ts
@@ -29,6 +29,10 @@ interface TabState {
   tabs: Tab[];
   activeTabId: string | null;
   autoSaveError: string | null;
+  // True once restoreTabs has finished loading tabs and collections. Until
+  // then persistTabs is a no-op so an early debounced persist cannot overwrite
+  // persisted collections/tabs with empty values before they finish loading.
+  hydrated: boolean;
 
   // Tab management
   newTab: () => void;
@@ -471,6 +475,7 @@ export const useTabStore = create<TabState>((set, get) => ({
   tabs: [],
   activeTabId: null,
   autoSaveError: null,
+  hydrated: false,
 
   newTab: () => {
     const tab = createEmptyTab();
@@ -1018,6 +1023,10 @@ export const useTabStore = create<TabState>((set, get) => ({
   },
 
   persistTabs: () => {
+    // Don't persist until the initial restore has completed. Otherwise the
+    // debounced startup persist can run before collections finish loading and
+    // overwrite the saved collection list with an empty array.
+    if (!get().hydrated) return;
     const { tabs, activeTabId } = get();
     // Only persist file-backed tabs (exclude ephemeral WS/SSE tabs), deduplicated
     const seen = new Set<string>();
@@ -1067,6 +1076,23 @@ export const useTabStore = create<TabState>((set, get) => ({
   },
 
   restoreTabs: async () => {
+    // Re-open the persisted collections and WAIT for them to load before
+    // hydration completes, so the collection store is populated before the
+    // first persist can run (otherwise it would save collections: []).
+    const openCollections = async (paths: Set<string>) => {
+      if (paths.size === 0) return;
+      try {
+        const { useCollectionStore } = await import("@/stores/collection-store");
+        await Promise.all(
+          [...paths].map((path) =>
+            useCollectionStore.getState().openCollection(path).catch(() => {}),
+          ),
+        );
+      } catch {
+        // Collection store unavailable — nothing to restore in the sidebar.
+      }
+    };
+
     try {
       const persisted = await loadPersistedState();
 
@@ -1081,13 +1107,7 @@ export const useTabStore = create<TabState>((set, get) => ({
 
       if (persisted.tabs.length === 0) {
         // No tabs to restore, but still re-open collections
-        if (collectionPaths.size > 0) {
-          import("@/stores/collection-store").then(({ useCollectionStore }) => {
-            for (const path of collectionPaths) {
-              useCollectionStore.getState().openCollection(path).catch(() => {});
-            }
-          });
-        }
+        await openCollections(collectionPaths);
         return;
       }
       const seenPaths = new Set<string>();
@@ -1122,17 +1142,14 @@ export const useTabStore = create<TabState>((set, get) => ({
 
       // Re-open collections in the sidebar (persisted collections were
       // already added above; this also includes any from open tabs).
-      if (collectionPaths.size > 0) {
-        import("@/stores/collection-store").then(({ useCollectionStore }) => {
-          for (const path of collectionPaths) {
-            useCollectionStore.getState().openCollection(path).catch(() => {});
-          }
-        });
-      }
+      await openCollections(collectionPaths);
     } catch (err) {
       import("@/stores/toast-store").then(({ useToastStore }) =>
         useToastStore.getState().showWarning("Some tabs could not be restored from your last session.")
       );
+    } finally {
+      // Hydration complete — persistTabs is now allowed to write.
+      set({ hydrated: true });
     }
   },
 }));


### PR DESCRIPTION
## Problem

Opening the app could clear the sidebar's collection registration: `~/.apiark/state.json` ends up with `"collections": []`, so the user's collections appear deleted. The request files on disk are never touched — only the persisted registration is lost.

## Root cause

`persistTabs()` derives the persisted collection list from the live collection store. On startup:

- `restoreTabs()` re-opens collections **asynchronously and fire-and-forget** (`import()` → `checkCollectionVersion` → `openCollectionApi` reads the whole tree from disk).
- The persist effect in `App.tsx` runs `persistTabs()` on a **500 ms debounce** whenever tabs change.

If the debounced persist fires **before** the collections finish loading into the store, `persistTabs` reads an empty list and overwrites the saved collections with `[]`. A single slow startup is enough to lose the registration.

## Fix

Add a `hydrated` flag to the tab store:

- `persistTabs()` is a **no-op until `hydrated` is true**, so an early debounced persist can't clobber collections.
- `restoreTabs()` now **awaits** the collection loads and sets `hydrated = true` in a `finally` block.

No data is ever wiped before the initial restore completes.

## Tests

`apps/desktop/src/__tests__/stores/tab-store.test.ts`:
- *does not persist before hydration, so an early startup persist cannot wipe collections*
- *marks the store hydrated after restoreTabs completes*

Both fail without the fix and pass with it. Full `tab-store` suite green; `tsc --noEmit` clean.

Independent of #79 — this bug exists on `main`.