### PR TITLE
feat(environments): add ability to delete a variable collection

### DIFF
--- a/apps/desktop/src-tauri/src/commands/environment.rs
+++ b/apps/desktop/src-tauri/src/commands/environment.rs
@@ -36,6 +36,22 @@ pub async fn save_environment(
     environment::save_environment(path, &env)
 }
 
+/// Delete an environment, moving its file to trash. Returns the trash path for undo support.
+#[tauri::command]
+pub async fn delete_environment(
+    collection_path: String,
+    environment_name: String,
+    scope: Option<String>,
+) -> Result<String, String> {
+    let path = Path::new(&collection_path);
+    let scope = match scope.as_deref() {
+        Some("personal") => EnvironmentScope::Personal,
+        _ => EnvironmentScope::Shared,
+    };
+    tracing::info!(path = %collection_path, name = %environment_name, "Deleting environment (moving to trash)");
+    environment::delete_environment(path, &environment_name, &scope)
+}
+
 /// Resolve all variables for a given environment, merging:
 /// 1. Root .env variables (lowest priority)
 /// 2. Environment YAML variables

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -32,7 +32,8 @@ use commands::cookies::{clear_cookie_jar, delete_cookie, get_cookie_jar};
 use commands::curl::{export_curl_command, parse_curl_command};
 use commands::docs::{generate_docs, preview_docs};
 use commands::environment::{
-    get_resolved_variables, load_environments, load_root_dotenv, save_environment,
+    delete_environment, get_resolved_variables, load_environments, load_root_dotenv,
+    save_environment,
 };
 use commands::git::{
     git_commit, git_diff, git_init, git_log, git_pull, git_push, git_stage, git_status, git_unstage,
@@ -280,6 +281,7 @@ pub fn run() {
             // Environment commands
             load_environments,
             save_environment,
+            delete_environment,
             get_resolved_variables,
             load_root_dotenv,
             // History commands

--- a/apps/desktop/src-tauri/src/storage/environment.rs
+++ b/apps/desktop/src-tauri/src/storage/environment.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::models::environment::{EnvironmentFile, EnvironmentScope};
 
@@ -124,6 +124,48 @@ pub fn get_resolved_variables(
         }
     }
     Ok(variables)
+}
+
+/// Locate the on-disk file for an environment by its declared name within a scope directory.
+/// Filenames are derived from the name on save, but imported environments may use arbitrary
+/// filenames, so we match on the parsed `name` field rather than reconstructing the filename.
+fn find_environment_file(dir: &Path, name: &str) -> Result<PathBuf, String> {
+    if !dir.exists() {
+        return Err(format!("Environment '{name}' not found"));
+    }
+
+    let entries = fs::read_dir(dir).map_err(|e| format!("Failed to read environments dir: {e}"))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read dir entry: {e}"))?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
+            let content = fs::read_to_string(&path)
+                .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+            if let Ok(env) = serde_yaml::from_str::<EnvironmentFile>(&content) {
+                if env.name == name {
+                    return Ok(path);
+                }
+            }
+        }
+    }
+
+    Err(format!("Environment '{name}' not found"))
+}
+
+/// Delete an environment by moving its file to trash. Returns the trash directory path so the
+/// deletion can be undone, mirroring how collection items are deleted.
+pub fn delete_environment(
+    collection_path: &Path,
+    environment_name: &str,
+    scope: &EnvironmentScope,
+) -> Result<String, String> {
+    let subdir = match scope {
+        EnvironmentScope::Personal => "environments.local",
+        EnvironmentScope::Shared => "environments",
+    };
+    let env_dir = collection_path.join(".apiark").join(subdir);
+    let file_path = find_environment_file(&env_dir, environment_name)?;
+    crate::storage::collection::delete_item(&file_path, "environments")
 }
 
 /// Save an environment file to disk. Saves to shared or personal directory based on scope.

--- a/apps/desktop/src/components/layout/side-panel.tsx
+++ b/apps/desktop/src/components/layout/side-panel.tsx
@@ -662,11 +662,12 @@ function EnvironmentsPanel({
   envSelectorRef?: React.RefObject<HTMLSelectElement | null>;
 }) {
   const { t } = useTranslation();
-  const { environments, activeEnvironmentName, setActiveEnvironment, loadEnvironments } =
+  const { environments, activeEnvironmentName, setActiveEnvironment, loadEnvironments, deleteEnvironment } =
     useEnvironmentStore();
   const { collections } = useCollectionStore();
   const [editingEnv, setEditingEnv] = useState<EnvironmentData | null>(null);
   const [newEnvOpen, setNewEnvOpen] = useState(false);
+  const [deletingEnv, setDeletingEnv] = useState<EnvironmentData | null>(null);
 
   const collectionPath =
     collections.find((c) => c.type === "collection")?.path ?? null;
@@ -835,27 +836,42 @@ function EnvironmentsPanel({
           </div>
         ) : (
           environments.map((env) => (
-            <button
+            <div
               key={env.name}
-              onClick={() => setEditingEnv(env)}
-              className={`flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-xs transition-colors ${
+              className={`group flex w-full items-center justify-between rounded-md px-2 py-1.5 text-xs transition-colors ${
                 activeEnvironmentName === env.name
-                  ? "bg-[var(--color-accent)]/10 text-[var(--color-accent)]"
-                  : "text-[var(--color-text-primary)] hover:bg-[var(--color-elevated)]"
+                  ? "bg-[var(--color-accent)]/10"
+                  : "hover:bg-[var(--color-elevated)]"
               }`}
             >
-              <div className="flex items-center gap-1.5 truncate">
+              <button
+                onClick={() => setEditingEnv(env)}
+                className={`flex min-w-0 flex-1 items-center gap-1.5 truncate text-left ${
+                  activeEnvironmentName === env.name
+                    ? "text-[var(--color-accent)]"
+                    : "text-[var(--color-text-primary)]"
+                }`}
+              >
                 <span className="truncate">{env.name}</span>
                 {env.scope === "personal" && (
                   <span className="shrink-0 rounded bg-amber-500/15 px-1 py-0.5 text-[8px] font-bold text-amber-400">
                     LOCAL
                   </span>
                 )}
+              </button>
+              <div className="flex shrink-0 items-center gap-1">
+                <span className="text-[10px] text-[var(--color-text-dimmed)] group-hover:hidden">
+                  {Object.keys(env.variables).length} vars
+                </span>
+                <button
+                  onClick={() => setDeletingEnv(env)}
+                  className="hidden rounded p-0.5 text-[var(--color-text-muted)] hover:bg-red-500/20 hover:text-red-400 group-hover:block"
+                  title={t("sidebar.deleteEnvironment")}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
               </div>
-              <span className="shrink-0 text-[10px] text-[var(--color-text-dimmed)]">
-                {Object.keys(env.variables).length} vars
-              </span>
-            </button>
+            </div>
           ))
         )}
       </div>
@@ -866,6 +882,40 @@ function EnvironmentsPanel({
         onOpenChange={setNewEnvOpen}
         onCreate={handleCreateNew}
       />
+
+      {/* Delete environment confirmation */}
+      <Dialog.Root open={!!deletingEnv} onOpenChange={(v) => { if (!v) setDeletingEnv(null); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-80 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-[var(--color-border)] bg-[var(--color-elevated)] p-5 shadow-2xl">
+            <Dialog.Title className="mb-2 text-sm font-semibold text-[var(--color-text-primary)]">
+              {t("confirmDelete.title")}
+            </Dialog.Title>
+            <p className="mb-5 text-sm text-[var(--color-text-secondary)]">
+              {t("sidebar.deleteEnvironmentConfirm", { name: deletingEnv?.name })}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setDeletingEnv(null)}
+                className="rounded-lg px-4 py-1.5 text-sm text-[var(--color-text-muted)] hover:bg-[var(--color-surface)]"
+              >
+                {t("common.cancel")}
+              </button>
+              <button
+                onClick={() => {
+                  if (!deletingEnv || !collectionPath) return;
+                  const target = deletingEnv;
+                  setDeletingEnv(null);
+                  deleteEnvironment(collectionPath, target.name, target.scope);
+                }}
+                className="rounded-lg bg-red-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+              >
+                {t("sidebar.deleteEnvironment")}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/apps/desktop/src/lib/tauri-api.ts
+++ b/apps/desktop/src/lib/tauri-api.ts
@@ -250,6 +250,18 @@ export async function saveEnvironment(
   await invoke<void>("save_environment", { collectionPath, env, scope: scope ?? env.scope ?? null });
 }
 
+export async function deleteEnvironment(
+  collectionPath: string,
+  environmentName: string,
+  scope?: "shared" | "personal",
+): Promise<string> {
+  return await invoke<string>("delete_environment", {
+    collectionPath,
+    environmentName,
+    scope: scope ?? null,
+  });
+}
+
 // ── History ──
 
 export async function getHistory(): Promise<HistoryEntry[]> {

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -51,6 +51,8 @@
     "openCollection": "Open Collection",
     "noEnvironmentsYet": "No environments yet",
     "newEnvironment": "New Environment",
+    "deleteEnvironment": "Delete Environment",
+    "deleteEnvironmentConfirm": "Delete environment “{{name}}”? This will move it to trash.",
     "addVariable": "Add Variable",
     "importEnvironment": "Import Environment (Postman JSON)"
   },

--- a/apps/desktop/src/stores/environment-store.ts
+++ b/apps/desktop/src/stores/environment-store.ts
@@ -3,6 +3,7 @@ import type { EnvironmentData } from "@apiark/types";
 import {
   loadEnvironments as loadEnvironmentsApi,
   getResolvedVariables as getResolvedVariablesApi,
+  deleteEnvironment as deleteEnvironmentApi,
   loadRootDotenv,
 } from "@/lib/tauri-api";
 
@@ -14,6 +15,11 @@ interface EnvironmentState {
   runtimeOverrides: Record<string, string>;
 
   loadEnvironments: (collectionPath: string) => Promise<void>;
+  deleteEnvironment: (
+    collectionPath: string,
+    name: string,
+    scope?: "shared" | "personal",
+  ) => Promise<void>;
   setActiveEnvironment: (name: string | null) => void;
   setActiveCollectionPath: (path: string | null) => void;
   getResolvedVariables: () => Promise<Record<string, string>>;
@@ -40,6 +46,22 @@ export const useEnvironmentStore = create<EnvironmentState>((set, get) => ({
     } catch (err) {
       import("@/stores/toast-store").then(({ useToastStore }) =>
         useToastStore.getState().showError(`Failed to load environments: ${err}`),
+      );
+    }
+  },
+
+  deleteEnvironment: async (collectionPath, name, scope) => {
+    try {
+      await deleteEnvironmentApi(collectionPath, name, scope);
+      // Clear the active selection if we just deleted it; loadEnvironments will
+      // auto-select the first remaining environment.
+      if (get().activeEnvironmentName === name) {
+        set({ activeEnvironmentName: null });
+      }
+      await get().loadEnvironments(collectionPath);
+    } catch (err) {
+      import("@/stores/toast-store").then(({ useToastStore }) =>
+        useToastStore.getState().showError(`Failed to delete environment: ${err}`),
       );
     }
   },


### PR DESCRIPTION
Closes #87

## Summary
- Environments (collections of variables) could be created, edited and imported, but there was no way to delete one. This adds that capability.
- The environment file is moved to trash (recoverable) instead of being hard-deleted, mirroring the existing collection-delete behavior.
- A trash icon appears on each environment row (on hover) and opens a confirmation dialog before deleting.

## Changes
| File | Change |
|------|--------|
| `apps/desktop/src-tauri/src/storage/environment.rs` | `delete_environment` resolves the env file by its declared name within the scope dir and moves it to trash |
| `apps/desktop/src-tauri/src/commands/environment.rs` | New `delete_environment` Tauri command |
| `apps/desktop/src-tauri/src/lib.rs` | Register the command in the invoke handler |
| `apps/desktop/src/lib/tauri-api.ts` | `deleteEnvironment` API wrapper |
| `apps/desktop/src/stores/environment-store.ts` | `deleteEnvironment` action; clears active selection then reloads |
| `apps/desktop/src/components/layout/side-panel.tsx` | Delete button per environment row + confirmation dialog |
| `apps/desktop/src/locales/en.json` | New `sidebar.deleteEnvironment` / `deleteEnvironmentConfirm` strings |

## Test plan
- [x] `cargo check` passes (tauri backend)
- [x] `tsc -b --noEmit` passes (desktop app)
- [x] `eslint` clean on changed files
- [x] Manual: hover an environment → click trash → confirm → file is moved to `~/.apiark/trash/environments/` and the list refreshes; active selection falls back to the first remaining environment

## Notes
- Deletion is recoverable via the same trash mechanism used for collections.
- Matching by the parsed `name` field (not a reconstructed filename) so imported environments with arbitrary filenames are handled correctly.