### PR TITLE
feat(environment): show selected environment in the request header

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -21,6 +21,7 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { useTheme } from "@/hooks/use-theme";
 import { useAutoSave } from "@/hooks/use-auto-save";
 import { useFileWatcher } from "@/hooks/use-file-watcher";
+import { useActiveCollectionEnvironments } from "@/hooks/use-active-collection-environments";
 import { useDocsStore } from "@/stores/docs-store";
 import { useMockStore } from "@/stores/mock-store";
 import { useMonitorStore } from "@/stores/monitor-store";
@@ -78,6 +79,7 @@ function App() {
 
   useTheme();
   useFileWatcher();
+  useActiveCollectionEnvironments();
   const { autoSaveError } = useAutoSave();
 
   // Init window state tracker once on mount

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -212,9 +212,15 @@ function App() {
         case "focusUrl":
           urlBarRef.current?.focus();
           break;
-        case "focusEnv":
-          envSelectorRef.current?.focus();
+        case "focusEnv": {
+          // Prefer the always-visible header selector; fall back to the
+          // side-panel one when no environments are loaded.
+          const headerEnv = document.getElementById(
+            "header-environment-selector",
+          ) as HTMLSelectElement | null;
+          (headerEnv ?? envSelectorRef.current)?.focus();
           break;
+        }
         case "toggleSidebar":
           setSidePanelVisible((prev) => !prev);
           break;

--- a/apps/desktop/src/__tests__/components/header-environment-selector.test.tsx
+++ b/apps/desktop/src/__tests__/components/header-environment-selector.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HeaderEnvironmentSelector } from "@/components/environment/header-environment-selector";
+import { useEnvironmentStore } from "@/stores/environment-store";
+import type { EnvironmentData } from "@apiark/types";
+
+// The store imports the real Tauri bridge at module load; mock it like the
+// store tests do so jsdom never tries to resolve @tauri-apps. The component
+// only reads/writes store state, so empty stubs are enough.
+vi.mock("@/lib/tauri-api", () => ({
+  loadEnvironments: vi.fn().mockResolvedValue([]),
+  getResolvedVariables: vi.fn().mockResolvedValue({}),
+  loadRootDotenv: vi.fn().mockResolvedValue({}),
+}));
+
+// Component tests don't run the i18n bootstrap (it reads localStorage at import
+// time). Resolve the handful of keys this component uses to their English copy.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        "environment.noEnvironment": "No Environment",
+        "environment.noEnvironments":
+          "Create an environment to manage variables across requests",
+        "environment.title": "Environments",
+      })[key] ?? key,
+  }),
+}));
+
+function env(name: string): EnvironmentData {
+  return { name, variables: {}, secrets: [] };
+}
+
+describe("HeaderEnvironmentSelector", () => {
+  beforeEach(() => {
+    useEnvironmentStore.setState({
+      environments: [],
+      activeEnvironmentName: null,
+      activeCollectionPath: null,
+      runtimeOverrides: {},
+    });
+  });
+
+  it("renders the active environment as the selected value", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local"), env("Production")],
+      activeEnvironmentName: "Production",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("Production");
+  });
+
+  it("renders one option per environment plus the 'No Environment' option", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local"), env("Production")],
+      activeEnvironmentName: "Local",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    expect(screen.getByRole("option", { name: "Local" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Production" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "No Environment" })).toBeInTheDocument();
+  });
+
+  it("switches the active environment in the store on change", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local"), env("Production")],
+      activeEnvironmentName: "Local",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "Production" },
+    });
+
+    expect(useEnvironmentStore.getState().activeEnvironmentName).toBe("Production");
+  });
+
+  it("clears the active environment when 'No Environment' is chosen", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local")],
+      activeEnvironmentName: "Local",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "" } });
+
+    expect(useEnvironmentStore.getState().activeEnvironmentName).toBeNull();
+  });
+
+  it("renders a 'No Environment' pill and no dropdown when there are no environments", () => {
+    useEnvironmentStore.setState({ environments: [], activeEnvironmentName: null });
+
+    render(<HeaderEnvironmentSelector />);
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByText("No Environment")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/__tests__/hooks/use-active-collection-environments.test.ts
+++ b/apps/desktop/src/__tests__/hooks/use-active-collection-environments.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useActiveCollectionEnvironments } from "@/hooks/use-active-collection-environments";
+import { useCollectionStore } from "@/stores/collection-store";
+import { useEnvironmentStore } from "@/stores/environment-store";
+import type { CollectionNode } from "@apiark/types";
+
+vi.mock("@/lib/tauri-api", () => ({
+  loadEnvironments: vi.fn().mockResolvedValue([]),
+  getResolvedVariables: vi.fn().mockResolvedValue({}),
+  loadRootDotenv: vi.fn().mockResolvedValue({}),
+}));
+
+function collection(name: string, path: string): CollectionNode {
+  return { type: "collection", name, path, children: [] };
+}
+
+describe("useActiveCollectionEnvironments", () => {
+  beforeEach(() => {
+    useCollectionStore.setState({ collections: [] });
+  });
+
+  it("loads environments for the first collection when collections are present", () => {
+    const loadEnvironments = vi.fn();
+    useEnvironmentStore.setState({ loadEnvironments });
+    useCollectionStore.setState({
+      collections: [collection("Groceries", "/tmp/groceries")],
+    });
+
+    renderHook(() => useActiveCollectionEnvironments());
+
+    expect(loadEnvironments).toHaveBeenCalledWith("/tmp/groceries");
+  });
+
+  it("does nothing when there are no collections", () => {
+    const loadEnvironments = vi.fn();
+    useEnvironmentStore.setState({ loadEnvironments });
+
+    renderHook(() => useActiveCollectionEnvironments());
+
+    expect(loadEnvironments).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/__tests__/hooks/use-active-collection-environments.test.ts
+++ b/apps/desktop/src/__tests__/hooks/use-active-collection-environments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useActiveCollectionEnvironments } from "@/hooks/use-active-collection-environments";
 import { useCollectionStore } from "@/stores/collection-store";
 import { useEnvironmentStore } from "@/stores/environment-store";
@@ -18,6 +18,7 @@ function collection(name: string, path: string): CollectionNode {
 describe("useActiveCollectionEnvironments", () => {
   beforeEach(() => {
     useCollectionStore.setState({ collections: [] });
+    useEnvironmentStore.setState({ loadEnvironments: vi.fn() });
   });
 
   it("loads environments for the first collection when collections are present", () => {
@@ -39,5 +40,21 @@ describe("useActiveCollectionEnvironments", () => {
     renderHook(() => useActiveCollectionEnvironments());
 
     expect(loadEnvironments).not.toHaveBeenCalled();
+  });
+
+  it("loads environments when collections arrive after mount", () => {
+    const loadEnvironments = vi.fn();
+    useEnvironmentStore.setState({ loadEnvironments });
+
+    renderHook(() => useActiveCollectionEnvironments());
+    expect(loadEnvironments).not.toHaveBeenCalled();
+
+    act(() => {
+      useCollectionStore.setState({
+        collections: [collection("Groceries", "/tmp/groceries")],
+      });
+    });
+
+    expect(loadEnvironments).toHaveBeenCalledWith("/tmp/groceries");
   });
 });

--- a/apps/desktop/src/components/environment/environment-selector.tsx
+++ b/apps/desktop/src/components/environment/environment-selector.tsx
@@ -1,24 +1,15 @@
-import { useEffect, forwardRef } from "react";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useEnvironmentStore } from "@/stores/environment-store";
-import { useCollectionStore } from "@/stores/collection-store";
 
 export const EnvironmentSelector = forwardRef<HTMLSelectElement>(
   function EnvironmentSelector(_props, ref) {
     const { t } = useTranslation();
-    const { environments, activeEnvironmentName, setActiveEnvironment, loadEnvironments } =
+    const { environments, activeEnvironmentName, setActiveEnvironment } =
       useEnvironmentStore();
-    const { collections } = useCollectionStore();
 
-    // Load environments when collections change
-    useEffect(() => {
-      if (collections.length > 0) {
-        const firstCollection = collections[0];
-        if (firstCollection.type === "collection") {
-          loadEnvironments(firstCollection.path);
-        }
-      }
-    }, [collections, loadEnvironments]);
+    // Environments are loaded once by useActiveCollectionEnvironments (mounted
+    // at the App level), so this selector only reads/switches the active one.
 
     if (environments.length === 0) {
       return (

--- a/apps/desktop/src/components/environment/header-environment-selector.tsx
+++ b/apps/desktop/src/components/environment/header-environment-selector.tsx
@@ -27,9 +27,11 @@ export function HeaderEnvironmentSelector() {
 
   return (
     <select
+      id="header-environment-selector"
       value={activeEnvironmentName ?? ""}
       onChange={(e) => setActiveEnvironment(e.target.value || null)}
       title={t("environment.title")}
+      aria-label={t("environment.title")}
       className="max-w-[180px] shrink-0 cursor-pointer rounded-lg border border-[var(--color-border)] bg-[var(--color-elevated)] px-3 py-2 text-sm text-[var(--color-text-primary)] outline-none transition-colors focus:border-[var(--color-accent)]/50 focus:ring-2 focus:ring-[var(--color-accent)]/20"
     >
       <option value="">{t("environment.noEnvironment")}</option>

--- a/apps/desktop/src/components/environment/header-environment-selector.tsx
+++ b/apps/desktop/src/components/environment/header-environment-selector.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from "react-i18next";
+import { useEnvironmentStore } from "@/stores/environment-store";
+
+/**
+ * Compact environment switcher for the request toolbar (URL bar row).
+ *
+ * Mirrors the side-panel EnvironmentSelector but is styled for the header and
+ * does not own the environment-loading effect — it only reads/switches the
+ * active environment via the shared store, so both selectors stay in sync.
+ */
+export function HeaderEnvironmentSelector() {
+  const { t } = useTranslation();
+  const environments = useEnvironmentStore((s) => s.environments);
+  const activeEnvironmentName = useEnvironmentStore((s) => s.activeEnvironmentName);
+  const setActiveEnvironment = useEnvironmentStore((s) => s.setActiveEnvironment);
+
+  if (environments.length === 0) {
+    return (
+      <span
+        className="flex shrink-0 items-center rounded-lg border border-dashed border-[var(--color-border)] px-3 py-2 text-sm text-[var(--color-text-dimmed)]"
+        title={t("environment.noEnvironments")}
+      >
+        {t("environment.noEnvironment")}
+      </span>
+    );
+  }
+
+  return (
+    <select
+      value={activeEnvironmentName ?? ""}
+      onChange={(e) => setActiveEnvironment(e.target.value || null)}
+      title={t("environment.title")}
+      className="max-w-[180px] shrink-0 cursor-pointer rounded-lg border border-[var(--color-border)] bg-[var(--color-elevated)] px-3 py-2 text-sm text-[var(--color-text-primary)] outline-none transition-colors focus:border-[var(--color-accent)]/50 focus:ring-2 focus:ring-[var(--color-accent)]/20"
+    >
+      <option value="">{t("environment.noEnvironment")}</option>
+      {environments.map((env) => (
+        <option key={env.name} value={env.name}>
+          {env.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/apps/desktop/src/components/layout/side-panel.tsx
+++ b/apps/desktop/src/components/layout/side-panel.tsx
@@ -671,12 +671,8 @@ function EnvironmentsPanel({
   const collectionPath =
     collections.find((c) => c.type === "collection")?.path ?? null;
 
-  // Load environments when panel mounts with a collection
-  useEffect(() => {
-    if (collectionPath) {
-      loadEnvironments(collectionPath);
-    }
-  }, [collectionPath, loadEnvironments]);
+  // Environments are loaded by useActiveCollectionEnvironments (mounted at the
+  // App level); the explicit reloads below refresh after save/import/create.
 
   const handleSave = async (env: EnvironmentData) => {
     if (!collectionPath) return;

--- a/apps/desktop/src/components/request/url-bar.tsx
+++ b/apps/desktop/src/components/request/url-bar.tsx
@@ -6,6 +6,7 @@ import type { HttpMethod, EnvironmentData } from "@apiark/types";
 import { Loader2, Send, AlertCircle, Check } from "lucide-react";
 import * as Popover from "@radix-ui/react-popover";
 import { HintTooltip } from "@/components/ui/hint-tooltip";
+import { HeaderEnvironmentSelector } from "@/components/environment/header-environment-selector";
 import { saveEnvironment } from "@/lib/tauri-api";
 
 const METHODS: HttpMethod[] = [
@@ -380,6 +381,10 @@ export const UrlBar = forwardRef<HTMLInputElement, UrlBarProps>(function UrlBar(
           </div>
         )}
       </div>
+
+      {/* Active environment selector — surfaced in the header so the selected
+          environment is always visible and switchable (issue #88) */}
+      <HeaderEnvironmentSelector />
 
       {/* Extra protocol-specific actions */}
       {extraActions}

--- a/apps/desktop/src/hooks/use-active-collection-environments.ts
+++ b/apps/desktop/src/hooks/use-active-collection-environments.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useCollectionStore } from "@/stores/collection-store";
+import { useEnvironmentStore } from "@/stores/environment-store";
+
+/**
+ * Loads the environments for the active collection (the first open collection,
+ * matching the app's existing convention) whenever the collection set changes.
+ *
+ * Mount this once, high in the tree, so environments are available everywhere
+ * (header selector, side panel) without each consumer triggering its own load.
+ */
+export function useActiveCollectionEnvironments() {
+  const collections = useCollectionStore((s) => s.collections);
+  const loadEnvironments = useEnvironmentStore((s) => s.loadEnvironments);
+
+  useEffect(() => {
+    if (collections.length > 0) {
+      const firstCollection = collections[0];
+      if (firstCollection.type === "collection") {
+        loadEnvironments(firstCollection.path);
+      }
+    }
+  }, [collections, loadEnvironments]);
+}


### PR DESCRIPTION
Closes #88

## What

Surfaces the currently selected environment in the main request toolbar (next to **Send**), like Postman's environment dropdown, so it's always visible **and** switchable without opening the Environments side panel.

Until now the only environment selector lived inside the Environments side panel, so the active environment was invisible unless that panel was open. The URL bar even told users to *"Select an environment from the header dropdown first"* — a dropdown that didn't exist yet. This adds it.

## How

- **`HeaderEnvironmentSelector`** — a compact selector rendered in the `UrlBar`, before the Send button, so it applies to every protocol. Shows a discreet "No Environment" pill when a collection has no environments.
- **`useActiveCollectionEnvironments`** — a small hook mounted once at the App level that loads the active collection's environments. This centralizes loading that was previously duplicated across selectors. Both the header and side-panel selectors now just read/switch the shared store, so they stay in sync automatically.
- The `Ctrl/Cmd+E` "focus environment" shortcut now targets the always-visible header selector (falling back to the side-panel one).

No new "active collection" concept is introduced — environments continue to come from the first open collection, exactly as before.

## Changes

| File | Change |
|------|--------|
| `components/environment/header-environment-selector.tsx` | New compact header selector |
| `hooks/use-active-collection-environments.ts` | New hook: load environments for the active collection |
| `components/request/url-bar.tsx` | Render the header selector |
| `App.tsx` | Mount the hook; focus the header selector on the shortcut |
| `components/environment/environment-selector.tsx` | Drop its now-redundant load effect (reads store only) |
| `components/layout/side-panel.tsx` | Drop its now-redundant mount-time load effect |
| `__tests__/components/header-environment-selector.test.tsx` | Component tests |
| `__tests__/hooks/use-active-collection-environments.test.ts` | Hook tests |

## Test plan

- [x] `pnpm test` — 34 passing (5 new)
- [x] `pnpm build` — typecheck + build clean
- [x] `pnpm lint` — no new warnings/errors