### PR TITLE
fix: disable auto-capitalize and auto-correct on text inputs

### DIFF
--- a/apps/desktop/eslint.config.js
+++ b/apps/desktop/eslint.config.js
@@ -30,6 +30,29 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-empty-object-type": "off",
       "@typescript-eslint/no-require-imports": "off",
+      // Force text-entry fields through the shared UI wrappers, which disable
+      // auto-capitalize/auto-correct. Raw inputs break on macOS WKWebView (#86).
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector: "JSXOpeningElement[name.name='textarea']",
+          message:
+            "Use the shared <TextArea> from @/components/ui/textarea instead of a raw <textarea>. It disables auto-capitalize/auto-correct (broken on macOS WKWebView).",
+        },
+        {
+          selector:
+            "JSXOpeningElement[name.name='input']:not(:has(JSXAttribute[name.name='type'] JSXExpressionContainer)):not(:has(JSXAttribute[name.name='type'][value.value=/^(checkbox|radio|file|range|color|button|submit|reset|image)$/]))",
+          message:
+            "Use the shared <Input> from @/components/ui/input for text-entry inputs instead of a raw <input>. It disables auto-capitalize/auto-correct (broken on macOS WKWebView).",
+        },
+      ],
+    },
+  },
+  {
+    // The shared wrappers are the one legitimate place to render raw elements.
+    files: ["src/components/ui/input.tsx", "src/components/ui/textarea.tsx"],
+    rules: {
+      "no-restricted-syntax": "off",
     },
   },
 );

--- a/apps/desktop/src/components/ai/ai-assistant-dialog.tsx
+++ b/apps/desktop/src/components/ai/ai-assistant-dialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
+import { TextArea } from "@/components/ui/textarea";
 import {
   X,
   Send,
@@ -409,7 +410,7 @@ export function AiAssistantDialog({ open, onOpenChange }: AiAssistantDialogProps
               {/* Input */}
               <div className="border-t border-[var(--color-border)] px-4 py-3">
                 <div className="flex items-end gap-2">
-                  <textarea
+                  <TextArea
                     ref={inputRef}
                     value={input}
                     onChange={(e) => setInput(e.target.value)}
@@ -417,6 +418,9 @@ export function AiAssistantDialog({ open, onOpenChange }: AiAssistantDialogProps
                     disabled={loading}
                     className="flex-1 resize-none rounded-lg bg-[var(--color-elevated)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none focus:ring-1 focus:ring-purple-500 disabled:opacity-50"
                     rows={2}
+                    autoCapitalize="sentences"
+                    autoCorrect="on"
+                    spellCheck={true}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" && !e.shiftKey) {
                         e.preventDefault();

--- a/apps/desktop/src/components/collection/collection-sidebar.tsx
+++ b/apps/desktop/src/components/collection/collection-sidebar.tsx
@@ -10,6 +10,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { createCollection } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
 import * as Dialog from "@radix-ui/react-dialog";
+import { Input } from "@/components/ui/input";
 
 type SidebarSection = "collections" | "environments" | "history";
 
@@ -99,7 +100,7 @@ export function CollectionSidebar({ onOpenSettings, collapsed, envSelectorRef, o
               {collections.length > 0 && (
                 <div className="relative mb-1 px-2">
                   <Search className="absolute left-4 top-1/2 h-3 w-3 -translate-y-1/2 text-[var(--color-text-dimmed)]" />
-                  <input
+                  <Input
                     type="text"
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
@@ -313,7 +314,7 @@ function NewCollectionDialog({
               <label className="text-xs font-medium text-[var(--color-text-secondary)]">
                 {t("sidebar.collectionName")}
               </label>
-              <input
+              <Input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -331,7 +332,7 @@ function NewCollectionDialog({
                 {t("sidebar.location")}
               </label>
               <div className="flex gap-2">
-                <input
+                <Input
                   type="text"
                   value={parentDir}
                   readOnly

--- a/apps/desktop/src/components/collection/collection-tree.tsx
+++ b/apps/desktop/src/components/collection/collection-tree.tsx
@@ -26,6 +26,7 @@ import {
 import { getCollectionDefaults, updateCollectionDefaults } from "@/lib/tauri-api";
 import * as Dialog from "@radix-ui/react-dialog";
 import { CookieJarDialog } from "@/components/collection/cookie-jar-dialog";
+import { Input } from "@/components/ui/input";
 import { exportCollectionToFile } from "@/lib/export-collection";
 import { saveFolderOrder } from "@/lib/tauri-api";
 import {
@@ -536,7 +537,7 @@ function TreeNodeRow({
               : node.method}
           </span>
           {renaming ? (
-            <input
+            <Input
               autoFocus
               value={renameValue}
               onChange={(e) => setRenameValue(e.target.value)}
@@ -635,7 +636,7 @@ function TreeNodeRow({
           <Folder className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-muted)]" />
         )}
         {renaming ? (
-          <input
+          <Input
             autoFocus
             value={renameValue}
             onChange={(e) => setRenameValue(e.target.value)}
@@ -1017,7 +1018,7 @@ function InputDialog({
           <Dialog.Title className="mb-4 text-sm font-semibold text-[var(--color-text-primary)]">
             {title}
           </Dialog.Title>
-          <input
+          <Input
             ref={inputRef}
             type="text"
             value={value}

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -23,6 +23,7 @@ import { useMonitorStore } from "@/stores/monitor-store";
 import { useDocsStore } from "@/stores/docs-store";
 import { exportCollectionToFile } from "@/lib/export-collection";
 import type { CollectionNode, ExportFormat } from "@apiark/types";
+import { Input } from "@/components/ui/input";
 
 interface Command {
   id: string;
@@ -369,7 +370,7 @@ export function CommandPalette({
           <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-3">
             <Search className="h-4 w-4 shrink-0 text-[var(--color-text-muted)]" />
             <Dialog.Title className="sr-only">Command Palette</Dialog.Title>
-            <input
+            <Input
               ref={inputRef}
               type="text"
               value={query}

--- a/apps/desktop/src/components/git/git-panel.tsx
+++ b/apps/desktop/src/components/git/git-panel.tsx
@@ -15,6 +15,7 @@ import {
   ChevronRight,
   Clock,
 } from "lucide-react";
+import { TextArea } from "@/components/ui/textarea";
 
 export function GitPanel() {
   const { collections } = useCollectionStore();
@@ -254,7 +255,7 @@ export function GitPanel() {
       {/* Commit box */}
       {stagedChanges.length > 0 && (
         <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-elevated)] p-2">
-          <textarea
+          <TextArea
             value={commitMessage}
             onChange={(e) => setCommitMessage(e.target.value)}
             placeholder="Commit message..."

--- a/apps/desktop/src/components/graphql/graphql-view.tsx
+++ b/apps/desktop/src/components/graphql/graphql-view.tsx
@@ -15,6 +15,7 @@ import {
 import type { AuthConfig } from "@apiark/types";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { UrlBar } from "@/components/request/url-bar";
+import { Input } from "@/components/ui/input";
 import {
   useGraphQLSubscription,
   type GqlSubscriptionMessage,
@@ -235,7 +236,7 @@ export function GraphQLView() {
                       </span>
                     )}
                   </div>
-                  <input
+                  <Input
                     type="text"
                     value={tab.graphql.operationName}
                     onChange={(e) =>
@@ -488,7 +489,7 @@ function AuthEditorCompact({
       </select>
 
       {auth.type === "bearer" && (
-        <input
+        <Input
           type="text"
           value={auth.token}
           onChange={(e) => onChange({ ...auth, token: e.target.value })}
@@ -499,7 +500,7 @@ function AuthEditorCompact({
 
       {auth.type === "basic" && (
         <div className="space-y-2">
-          <input
+          <Input
             type="text"
             value={auth.username}
             onChange={(e) =>
@@ -508,7 +509,7 @@ function AuthEditorCompact({
             placeholder={t("auth.username")}
             className="w-full rounded bg-[var(--color-elevated)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none"
           />
-          <input
+          <Input
             type="password"
             value={auth.password}
             onChange={(e) =>

--- a/apps/desktop/src/components/grpc/grpc-view.tsx
+++ b/apps/desktop/src/components/grpc/grpc-view.tsx
@@ -8,6 +8,8 @@ import { Upload, Send, Loader2, Trash2, ArrowDown, ArrowUp, Plus, X, Search, Che
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { UrlBar } from "@/components/request/url-bar";
 import { KeyValueEditor } from "@/components/request/key-value-editor";
+import { Input } from "@/components/ui/input";
+import { TextArea } from "@/components/ui/textarea";
 
 interface StreamMessage {
   body: string;
@@ -303,7 +305,7 @@ export function GrpcView() {
                           </button>
                         )}
                       </div>
-                      <textarea
+                      <TextArea
                         value={msg}
                         onChange={(e) => {
                           const updated = [...clientMessages];
@@ -325,7 +327,7 @@ export function GrpcView() {
                 <label className="mb-1 block text-xs font-medium text-[var(--color-text-muted)]">
                   {t("grpc.requestBody")}
                 </label>
-                <textarea
+                <TextArea
                   value={grpc.requestJson}
                   onChange={(e) => updateGrpc({ requestJson: e.target.value })}
                   className="h-full w-full resize-none rounded bg-[var(--color-elevated)] p-3 font-mono text-sm text-[var(--color-text-primary)] outline-none focus:ring-1 focus:ring-blue-500"
@@ -512,7 +514,7 @@ function MethodBrowser({
       {showFilter && (
         <div className="flex items-center gap-1.5 border-b border-[var(--color-border)] px-3 py-1.5">
           <Search className="h-3 w-3 text-[var(--color-text-dimmed)]" />
-          <input
+          <Input
             type="text"
             value={filter}
             onChange={(e) => onFilterChange(e.target.value)}

--- a/apps/desktop/src/components/history/history-panel.tsx
+++ b/apps/desktop/src/components/history/history-panel.tsx
@@ -7,6 +7,7 @@ import { Search, Trash2 } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { HistorySkeleton } from "@/components/ui/skeleton";
 import { EmptyState, ClockEmptyIcon } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
 
 const METHOD_COLORS: Record<string, string> = {
   GET: "text-green-500",
@@ -80,7 +81,7 @@ export function HistoryPanel() {
       <div className="mb-1 flex items-center gap-1">
         <div className="flex flex-1 items-center rounded bg-[var(--color-elevated)] px-2">
           <Search className="h-3 w-3 text-[var(--color-text-dimmed)]" />
-          <input
+          <Input
             type="text"
             value={searchQuery}
             onChange={(e) => handleSearch(e.target.value)}

--- a/apps/desktop/src/components/layout/side-panel.tsx
+++ b/apps/desktop/src/components/layout/side-panel.tsx
@@ -15,6 +15,7 @@ import type { ActivityView } from "./activity-bar";
 import { ProxySidePanel as ProxySidePanelView } from "@/components/proxy/proxy-panel";
 import { GitPanel as GitPanelView } from "@/components/git/git-panel";
 import { AuditPanel } from "@/components/audit/audit-panel";
+import { Input } from "@/components/ui/input";
 
 interface SidePanelProps {
   activeView: ActivityView;
@@ -104,7 +105,7 @@ function CollectionsPanel({ onOpenImport }: { onOpenImport?: () => void }) {
       {collections.length > 0 && (
         <div className="relative">
           <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--color-text-dimmed)]" />
-          <input
+          <Input
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -381,22 +382,22 @@ function CollectionDefaultsDialog({
               </div>
 
               {authType === "bearer" && (
-                <input type="text" value={token} onChange={(e) => setToken(e.target.value)} placeholder={t("auth.token")}
+                <Input type="text" value={token} onChange={(e) => setToken(e.target.value)} placeholder={t("auth.token")}
                   className="w-full rounded bg-[var(--color-elevated)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none" />
               )}
               {authType === "basic" && (
                 <div className="space-y-2">
-                  <input type="text" value={username} onChange={(e) => setUsername(e.target.value)} placeholder={t("auth.username")}
+                  <Input type="text" value={username} onChange={(e) => setUsername(e.target.value)} placeholder={t("auth.username")}
                     className="w-full rounded bg-[var(--color-elevated)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none" />
-                  <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder={t("auth.password")}
+                  <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder={t("auth.password")}
                     className="w-full rounded bg-[var(--color-elevated)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none" />
                 </div>
               )}
               {authType === "api-key" && (
                 <div className="space-y-2">
-                  <input type="text" value={apiKeyKey} onChange={(e) => setApiKeyKey(e.target.value)} placeholder="Header name"
+                  <Input type="text" value={apiKeyKey} onChange={(e) => setApiKeyKey(e.target.value)} placeholder="Header name"
                     className="w-full rounded bg-[var(--color-elevated)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none" />
-                  <input type="text" value={apiKeyValue} onChange={(e) => setApiKeyValue(e.target.value)} placeholder="Value"
+                  <Input type="text" value={apiKeyValue} onChange={(e) => setApiKeyValue(e.target.value)} placeholder="Value"
                     className="w-full rounded bg-[var(--color-elevated)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none" />
                 </div>
               )}
@@ -470,7 +471,7 @@ function CollectionHeader({
           <Folder className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-muted)]" />
         )}
         {renaming ? (
-          <input
+          <Input
             autoFocus
             value={renameValue}
             onChange={(e) => setRenameValue(e.target.value)}
@@ -594,7 +595,7 @@ function NewCollectionDialog({
               <label className="text-xs font-medium text-[var(--color-text-secondary)]">
                 {t("sidebar.collectionName")}
               </label>
-              <input
+              <Input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -612,7 +613,7 @@ function NewCollectionDialog({
                 {t("sidebar.location")}
               </label>
               <div className="flex gap-2">
-                <input
+                <Input
                   type="text"
                   value={parentDir}
                   readOnly
@@ -924,7 +925,7 @@ function EnvironmentEditor({
         >
           <X className="h-3.5 w-3.5" />
         </button>
-        <input
+        <Input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -973,14 +974,14 @@ function EnvironmentEditor({
 
         {variables.map((v, i) => (
           <div key={i} className="flex gap-1">
-            <input
+            <Input
               type="text"
               value={v.key}
               onChange={(e) => updateVar(i, "key", e.target.value)}
               placeholder={t("request.key")}
               className="min-w-0 flex-1 basis-0 rounded bg-[var(--color-elevated)] px-2 py-1 text-xs text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
             />
-            <input
+            <Input
               type="text"
               value={v.value}
               onChange={(e) => updateVar(i, "value", e.target.value)}
@@ -1038,7 +1039,7 @@ function NewEnvironmentDialog({
             </Dialog.Close>
           </div>
           <div className="p-4">
-            <input
+            <Input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}

--- a/apps/desktop/src/components/mock/mock-server-dialog.tsx
+++ b/apps/desktop/src/components/mock/mock-server-dialog.tsx
@@ -6,6 +6,7 @@ import { startMockServer, stopMockServer, listMockServers } from "@/lib/tauri-ap
 import { listen } from "@tauri-apps/api/event";
 import type { MockRequestLog } from "@apiark/types";
 import { Play, Square, Trash2, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
 
 export function MockServerDialog() {
   const { t } = useTranslation();
@@ -117,7 +118,7 @@ export function MockServerDialog() {
               <div className="flex gap-2">
                 <div className="flex-1">
                   <label className="block text-xs text-[var(--color-text-muted)]">{t("mock.port")}</label>
-                  <input
+                  <Input
                     type="number"
                     value={port}
                     onChange={(e) => setPort(Number(e.target.value))}
@@ -126,7 +127,7 @@ export function MockServerDialog() {
                 </div>
                 <div className="flex-1">
                   <label className="block text-xs text-[var(--color-text-muted)]">{t("mock.latency")}</label>
-                  <input
+                  <Input
                     type="number"
                     value={latencyMs}
                     onChange={(e) => setLatencyMs(Number(e.target.value))}
@@ -135,7 +136,7 @@ export function MockServerDialog() {
                 </div>
                 <div className="flex-1">
                   <label className="block text-xs text-[var(--color-text-muted)]">Error %</label>
-                  <input
+                  <Input
                     type="number"
                     min={0}
                     max={100}

--- a/apps/desktop/src/components/mqtt/mqtt-view.tsx
+++ b/apps/desktop/src/components/mqtt/mqtt-view.tsx
@@ -14,6 +14,8 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { Input } from "@/components/ui/input";
+import { TextArea } from "@/components/ui/textarea";
 
 export function MqttView() {
   const tab = useActiveTab();
@@ -106,7 +108,7 @@ export function MqttView() {
       <div className="flex items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2">
         <span className="text-xs font-medium text-[var(--color-text-muted)]">MQTT</span>
         <div className="flex flex-1 items-center gap-1.5">
-          <input
+          <Input
             type="text"
             value={brokerUrl}
             onChange={(e) => setBrokerUrl(e.target.value)}
@@ -115,7 +117,7 @@ export function MqttView() {
             className="flex-1 rounded bg-[var(--color-elevated)] px-2.5 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none focus:ring-1 focus:ring-purple-500 disabled:opacity-50"
           />
           <span className="text-xs text-[var(--color-text-dimmed)]">:</span>
-          <input
+          <Input
             type="text"
             value={port}
             onChange={(e) => setPort(e.target.value)}
@@ -172,7 +174,7 @@ export function MqttView() {
           <div className="grid grid-cols-2 gap-2 px-3 pb-2">
             <div>
               <label className="text-[10px] text-[var(--color-text-dimmed)]">Client ID</label>
-              <input
+              <Input
                 type="text"
                 value={clientId}
                 onChange={(e) => setClientId(e.target.value)}
@@ -189,7 +191,7 @@ export function MqttView() {
               </button>
               {showAuth && (
                 <div className="flex gap-2">
-                  <input
+                  <Input
                     type="text"
                     value={username}
                     onChange={(e) => setUsername(e.target.value)}
@@ -197,7 +199,7 @@ export function MqttView() {
                     disabled={status === "connected"}
                     className="flex-1 rounded bg-[var(--color-elevated)] px-2 py-1 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none focus:ring-1 focus:ring-purple-500 disabled:opacity-50"
                   />
-                  <input
+                  <Input
                     type="password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -227,7 +229,7 @@ export function MqttView() {
             Subscribe
           </div>
           <div className="flex items-center gap-1.5">
-            <input
+            <Input
               type="text"
               value={subTopic}
               onChange={(e) => setSubTopic(e.target.value)}
@@ -285,7 +287,7 @@ export function MqttView() {
             Publish
           </div>
           <div className="flex items-center gap-1.5">
-            <input
+            <Input
               type="text"
               value={pubTopic}
               onChange={(e) => setPubTopic(e.target.value)}
@@ -315,7 +317,7 @@ export function MqttView() {
             </label>
           </div>
           <div className="mt-1.5 flex items-end gap-1.5">
-            <textarea
+            <TextArea
               value={pubPayload}
               onChange={(e) => setPubPayload(e.target.value)}
               placeholder="Message payload"
@@ -350,7 +352,7 @@ export function MqttView() {
           <span className="text-purple-400">Topics: {subscriptions.length}</span>
         </div>
         <div className="flex items-center gap-2">
-          <input
+          <Input
             type="text"
             value={topicFilter}
             onChange={(e) => setTopicFilter(e.target.value)}

--- a/apps/desktop/src/components/proxy/proxy-panel.tsx
+++ b/apps/desktop/src/components/proxy/proxy-panel.tsx
@@ -25,6 +25,7 @@ import {
   Copy,
   Check,
 } from "lucide-react";
+import { Input } from "@/components/ui/input";
 
 export function ProxySidePanel() {
   const { status, setStatus } = useProxyStore();
@@ -114,7 +115,7 @@ export function ProxySidePanel() {
 
         <div className="flex items-center gap-2">
           {!status.running && (
-            <input
+            <Input
               type="text"
               value={port}
               onChange={(e) => setPort(e.target.value)}
@@ -206,7 +207,7 @@ export function ProxySidePanel() {
         </button>
         {showSettings && (
           <div className="px-3 pb-3">
-            <input
+            <Input
               type="text"
               value={passthrough}
               onChange={(e) => setPassthrough(e.target.value)}
@@ -296,7 +297,7 @@ export function ProxyCaptureViewer() {
         <div className="flex-1" />
         <div className="flex items-center gap-1 rounded-lg bg-[var(--color-elevated)] px-2 py-0.5">
           <Search className="h-3 w-3 text-[var(--color-text-dimmed)]" />
-          <input
+          <Input
             type="text"
             value={filter}
             onChange={(e) => setFilter(e.target.value)}

--- a/apps/desktop/src/components/request/curl-import-dialog.tsx
+++ b/apps/desktop/src/components/request/curl-import-dialog.tsx
@@ -4,6 +4,7 @@ import { X, Upload } from "lucide-react";
 import { parseCurlCommand } from "@/lib/tauri-api";
 import { useTabStore } from "@/stores/tab-store";
 import type { HttpMethod, KeyValuePair, BodyType } from "@apiark/types";
+import { TextArea } from "@/components/ui/textarea";
 
 let kvCounter = 0;
 const kvId = () => `kv_${Date.now()}_${++kvCounter}`;
@@ -86,7 +87,7 @@ export function CurlImportDialog({ open, onOpenChange }: CurlImportDialogProps) 
           </div>
 
           <div className="p-6">
-            <textarea
+            <TextArea
               value={curlInput}
               onChange={(e) => setCurlInput(e.target.value)}
               placeholder={'Paste your cURL command here...\n\ncurl -X POST https://api.example.com/users \\\n  -H \'Content-Type: application/json\' \\\n  -d \'{"name": "John"}\''}

--- a/apps/desktop/src/components/request/key-value-editor.tsx
+++ b/apps/desktop/src/components/request/key-value-editor.tsx
@@ -1,5 +1,6 @@
 import type { KeyValuePair } from "@apiark/types";
 import { Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
 
 let kvCounter = 0;
 const kvId = () => `kv_${Date.now()}_${++kvCounter}`;
@@ -58,14 +59,14 @@ export function KeyValueEditor({
             onChange={(e) => update(index, "enabled", e.target.checked)}
             className="h-4 w-4 accent-blue-500"
           />
-          <input
+          <Input
             type="text"
             value={pair.key}
             onChange={(e) => update(index, "key", e.target.value)}
             placeholder={keyPlaceholder}
             className="rounded bg-[var(--color-elevated)] px-2 py-1 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none focus:ring-1 focus:ring-blue-500"
           />
-          <input
+          <Input
             type="text"
             value={pair.value}
             onChange={(e) => update(index, "value", e.target.value)}

--- a/apps/desktop/src/components/request/request-panel.tsx
+++ b/apps/desktop/src/components/request/request-panel.tsx
@@ -7,6 +7,8 @@ import { oauthStartFlow, oauthGetTokenStatus, oauthClearToken } from "@/lib/taur
 import { HintTooltip } from "@/components/ui/hint-tooltip";
 import { CodeEditor } from "@/components/ui/code-editor";
 import { Plus, Trash2, FileUp } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { TextArea } from "@/components/ui/textarea";
 
 /** Extract :paramName path variables from a URL */
 function extractPathVariables(url: string): string[] {
@@ -215,7 +217,7 @@ function PathVariablesEditor({
           <div className="flex items-center rounded bg-[var(--color-elevated)] px-2 py-1 text-sm font-medium text-purple-400">
             :{param}
           </div>
-          <input
+          <Input
             type="text"
             value={values[param] ?? ""}
             onChange={(e) => handleChange(param, e.target.value)}
@@ -234,7 +236,7 @@ function PathVariablesEditor({
       {/* Add row — only show when no path vars exist yet or user started typing */}
       {(pathVars.length === 0 || newVarName) && (
         <div className="grid grid-cols-[1fr_1fr_auto] items-center gap-2 px-1">
-          <input
+          <Input
             type="text"
             value={newVarName}
             onChange={(e) => setNewVarName(e.target.value)}
@@ -323,7 +325,7 @@ function FormDataEditor({
             onChange={(e) => update(index, "enabled", e.target.checked)}
             className="h-4 w-4 accent-blue-500"
           />
-          <input
+          <Input
             type="text"
             value={pair.key}
             onChange={(e) => update(index, "key", e.target.value)}
@@ -331,7 +333,7 @@ function FormDataEditor({
             className="rounded bg-[var(--color-elevated)] px-2 py-1 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none focus:ring-1 focus:ring-blue-500"
           />
           <div className="flex items-center gap-1">
-            <input
+            <Input
               type="text"
               value={pair.value}
               onChange={(e) => {
@@ -641,7 +643,7 @@ function AuthEditor({
 
       {/* Auth fields */}
       {auth.type === "bearer" && (
-        <input
+        <Input
           type="text"
           value={auth.token}
           onChange={(e) => onChange({ ...auth, token: e.target.value })}
@@ -652,14 +654,14 @@ function AuthEditor({
 
       {auth.type === "basic" && (
         <div className="space-y-2">
-          <input
+          <Input
             type="text"
             value={auth.username}
             onChange={(e) => onChange({ ...auth, username: e.target.value })}
             placeholder={t("auth.username")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="password"
             value={auth.password}
             onChange={(e) => onChange({ ...auth, password: e.target.value })}
@@ -671,14 +673,14 @@ function AuthEditor({
 
       {auth.type === "api-key" && (
         <div className="space-y-2">
-          <input
+          <Input
             type="text"
             value={auth.key}
             onChange={(e) => onChange({ ...auth, key: e.target.value })}
             placeholder="Key name (e.g. X-API-Key)"
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.value}
             onChange={(e) => onChange({ ...auth, value: e.target.value })}
@@ -704,14 +706,14 @@ function AuthEditor({
 
       {auth.type === "digest" && (
         <div className="space-y-2">
-          <input
+          <Input
             type="text"
             value={auth.username}
             onChange={(e) => onChange({ ...auth, username: e.target.value })}
             placeholder={t("auth.username")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="password"
             value={auth.password}
             onChange={(e) => onChange({ ...auth, password: e.target.value })}
@@ -723,35 +725,35 @@ function AuthEditor({
 
       {auth.type === "aws-v4" && (
         <div className="space-y-2">
-          <input
+          <Input
             type="text"
             value={auth.accessKey}
             onChange={(e) => onChange({ ...auth, accessKey: e.target.value })}
             placeholder={t("auth.accessKey")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="password"
             value={auth.secretKey}
             onChange={(e) => onChange({ ...auth, secretKey: e.target.value })}
             placeholder={t("auth.secretKey")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.region}
             onChange={(e) => onChange({ ...auth, region: e.target.value })}
             placeholder={t("auth.region")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.service}
             onChange={(e) => onChange({ ...auth, service: e.target.value })}
             placeholder={t("auth.service")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.sessionToken}
             onChange={(e) => onChange({ ...auth, sessionToken: e.target.value })}
@@ -777,21 +779,21 @@ function AuthEditor({
             <option value="ES256">ES256</option>
             <option value="ES384">ES384</option>
           </select>
-          <input
+          <Input
             type="password"
             value={auth.secret}
             onChange={(e) => onChange({ ...auth, secret: e.target.value })}
             placeholder={auth.algorithm.startsWith("HS") ? "HMAC Secret" : "Private Key (PEM)"}
             className={INPUT_CLASS}
           />
-          <textarea
+          <TextArea
             value={auth.payload}
             onChange={(e) => onChange({ ...auth, payload: e.target.value })}
             placeholder='{"sub": "user", "iat": 0}'
             rows={5}
             className={INPUT_CLASS + " resize-y font-mono"}
           />
-          <input
+          <Input
             type="text"
             value={auth.headerPrefix}
             onChange={(e) => onChange({ ...auth, headerPrefix: e.target.value })}
@@ -803,28 +805,28 @@ function AuthEditor({
 
       {auth.type === "ntlm" && (
         <div className="space-y-2">
-          <input
+          <Input
             type="text"
             value={auth.username}
             onChange={(e) => onChange({ ...auth, username: e.target.value })}
             placeholder={t("auth.username")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="password"
             value={auth.password}
             onChange={(e) => onChange({ ...auth, password: e.target.value })}
             placeholder={t("auth.password")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.domain}
             onChange={(e) => onChange({ ...auth, domain: e.target.value })}
             placeholder={t("auth.domain")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.workstation}
             onChange={(e) => onChange({ ...auth, workstation: e.target.value })}
@@ -836,42 +838,42 @@ function AuthEditor({
 
       {auth.type === "saml" && (
         <div className="space-y-2">
-          <input
+          <Input
             type="text"
             value={auth.idpUrl}
             onChange={(e) => onChange({ ...auth, idpUrl: e.target.value })}
             placeholder={t("auth.idpUrl")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.entityId}
             onChange={(e) => onChange({ ...auth, entityId: e.target.value })}
             placeholder={t("auth.entityId")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.assertionConsumerUrl}
             onChange={(e) => onChange({ ...auth, assertionConsumerUrl: e.target.value })}
             placeholder={t("auth.assertionConsumerUrl")}
             className={INPUT_CLASS}
           />
-          <textarea
+          <TextArea
             value={auth.certificate}
             onChange={(e) => onChange({ ...auth, certificate: e.target.value })}
             placeholder={t("auth.certificate")}
             rows={3}
             className={INPUT_CLASS + " resize-y font-mono"}
           />
-          <input
+          <Input
             type="text"
             value={auth.nameIdFormat}
             onChange={(e) => onChange({ ...auth, nameIdFormat: e.target.value })}
             placeholder={t("auth.nameIdFormat")}
             className={INPUT_CLASS}
           />
-          <input
+          <Input
             type="text"
             value={auth.samlToken}
             onChange={(e) => onChange({ ...auth, samlToken: e.target.value })}
@@ -966,7 +968,7 @@ function OAuth2Editor({
       {showAuthUrl && (
         <label className="block">
           <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.authUrl")}</span>
-          <input
+          <Input
             type="text"
             value={auth.authUrl}
             onChange={(e) => onChange({ ...auth, authUrl: e.target.value })}
@@ -980,7 +982,7 @@ function OAuth2Editor({
       {showTokenUrl && (
         <label className="block">
           <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.tokenUrl")}</span>
-          <input
+          <Input
             type="text"
             value={auth.tokenUrl}
             onChange={(e) => onChange({ ...auth, tokenUrl: e.target.value })}
@@ -994,7 +996,7 @@ function OAuth2Editor({
       <div className="grid grid-cols-2 gap-2">
         <label className="block">
           <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.clientId")}</span>
-          <input
+          <Input
             type="text"
             value={auth.clientId}
             onChange={(e) => onChange({ ...auth, clientId: e.target.value })}
@@ -1004,7 +1006,7 @@ function OAuth2Editor({
         </label>
         <label className="block">
           <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.clientSecret")}</span>
-          <input
+          <Input
             type="password"
             value={auth.clientSecret}
             onChange={(e) => onChange({ ...auth, clientSecret: e.target.value })}
@@ -1017,7 +1019,7 @@ function OAuth2Editor({
       {/* Scope */}
       <label className="block">
         <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.scope")}</span>
-        <input
+        <Input
           type="text"
           value={auth.scope}
           onChange={(e) => onChange({ ...auth, scope: e.target.value })}
@@ -1031,7 +1033,7 @@ function OAuth2Editor({
         <div className="grid grid-cols-2 gap-2">
           <label className="block">
             <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.username")}</span>
-            <input
+            <Input
               type="text"
               value={auth.username}
               onChange={(e) => onChange({ ...auth, username: e.target.value })}
@@ -1041,7 +1043,7 @@ function OAuth2Editor({
           </label>
           <label className="block">
             <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.password")}</span>
-            <input
+            <Input
               type="password"
               value={auth.password}
               onChange={(e) => onChange({ ...auth, password: e.target.value })}
@@ -1056,7 +1058,7 @@ function OAuth2Editor({
       {showAuthUrl && (
         <label className="block">
           <span className="text-xs text-[var(--color-text-secondary)]">{t("auth.callbackUrl")}</span>
-          <input
+          <Input
             type="text"
             value={auth.callbackUrl}
             onChange={(e) => onChange({ ...auth, callbackUrl: e.target.value })}

--- a/apps/desktop/src/components/request/save-as-dialog.tsx
+++ b/apps/desktop/src/components/request/save-as-dialog.tsx
@@ -4,6 +4,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { X, FolderOpen, ChevronRight, ChevronDown } from "lucide-react";
 import { useCollectionStore } from "@/stores/collection-store";
 import type { CollectionNode } from "@apiark/types";
+import { Input } from "@/components/ui/input";
 
 interface SaveAsDialogProps {
   open: boolean;
@@ -83,7 +84,7 @@ export function SaveAsDialog({
               <label className="text-xs font-medium text-[var(--color-text-secondary)]">
                 {t("request.requestName")}
               </label>
-              <input
+              <Input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}

--- a/apps/desktop/src/components/request/url-bar.tsx
+++ b/apps/desktop/src/components/request/url-bar.tsx
@@ -7,6 +7,7 @@ import { Loader2, Send, AlertCircle, Check } from "lucide-react";
 import * as Popover from "@radix-ui/react-popover";
 import { HintTooltip } from "@/components/ui/hint-tooltip";
 import { saveEnvironment } from "@/lib/tauri-api";
+import { Input } from "@/components/ui/input";
 
 const METHODS: HttpMethod[] = [
   "GET",
@@ -161,7 +162,7 @@ function VariableEditor({
             </div>
           ) : (
             <div className="flex items-center gap-1.5">
-              <input
+              <Input
                 ref={inputRef}
                 type="text"
                 value={draft}
@@ -337,7 +338,7 @@ export const UrlBar = forwardRef<HTMLInputElement, UrlBarProps>(function UrlBar(
 
       {/* URL input with variable highlighting overlay */}
       <div className="relative flex-1">
-        <input
+        <Input
           ref={setRefs}
           type="text"
           value={tab.url}

--- a/apps/desktop/src/components/runner/collection-runner-dialog.tsx
+++ b/apps/desktop/src/components/runner/collection-runner-dialog.tsx
@@ -8,6 +8,7 @@ import { useRunnerStore } from "@/stores/runner-store";
 import { RunResultsTable } from "./run-results-table";
 import { exportAsJson, exportAsJUnit, downloadFile } from "@/lib/export-results";
 import type { RunConfig } from "@apiark/types";
+import { Input } from "@/components/ui/input";
 
 interface CollectionRunnerDialogProps {
   open: boolean;
@@ -111,7 +112,7 @@ export function CollectionRunnerDialog({
               <div className="grid grid-cols-3 gap-3">
                 <div>
                   <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Delay (ms)</label>
-                  <input
+                  <Input
                     type="number"
                     min={0}
                     value={delayMs}
@@ -121,7 +122,7 @@ export function CollectionRunnerDialog({
                 </div>
                 <div>
                   <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Iterations</label>
-                  <input
+                  <Input
                     type="number"
                     min={1}
                     value={iterations}

--- a/apps/desktop/src/components/scheduler/monitor-dialog.tsx
+++ b/apps/desktop/src/components/scheduler/monitor-dialog.tsx
@@ -12,6 +12,7 @@ import {
 import { listen } from "@tauri-apps/api/event";
 import type { MonitorResult } from "@apiark/types";
 import { Plus, Trash2, Play, Pause, X, Clock } from "lucide-react";
+import { Input } from "@/components/ui/input";
 
 const CRON_PRESETS = [
   { label: "Every minute", value: "0 * * * * *" },
@@ -152,7 +153,7 @@ export function MonitorDialog() {
           <div className="flex w-[340px] flex-col border-r border-[var(--color-border)]">
             {/* Create form */}
             <div className="space-y-2 border-b border-[var(--color-border)] p-3">
-              <input
+              <Input
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t("monitor.create")}
@@ -179,13 +180,13 @@ export function MonitorDialog() {
                   ))}
                 </select>
               </div>
-              <input
+              <Input
                 value={environmentName}
                 onChange={(e) => setEnvironmentName(e.target.value)}
                 placeholder="Environment (optional)"
                 className="w-full rounded bg-[var(--color-elevated)] px-2 py-1.5 text-xs text-[var(--color-text-primary)] outline-none"
               />
-              <input
+              <Input
                 value={webhookUrl}
                 onChange={(e) => setWebhookUrl(e.target.value)}
                 placeholder="Webhook URL (optional)"

--- a/apps/desktop/src/components/settings/settings-dialog.tsx
+++ b/apps/desktop/src/components/settings/settings-dialog.tsx
@@ -14,6 +14,7 @@ import type { AppSettings } from "@apiark/types";
 import { open as openFileDialog, save as saveFileDialog } from "@tauri-apps/plugin-dialog";
 import { exportAppState, importAppState } from "@/lib/tauri-api";
 import { tokenSwatchGroups } from "@/styles/tokens";
+import { Input } from "@/components/ui/input";
 
 interface SettingsDialogProps {
   open: boolean;
@@ -208,7 +209,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 <label className="mb-2 block text-sm text-[var(--color-text-secondary)]">
                   {t("settings.timeout")}
                 </label>
-                <input
+                <Input
                   type="number"
                   min={0}
                   step={1000}
@@ -223,7 +224,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 <label className="mb-2 block text-sm text-[var(--color-text-secondary)]">
                   {t("settings.proxyUrl")}
                 </label>
-                <input
+                <Input
                   type="text"
                   value={settings.proxyUrl ?? ""}
                   onChange={(e) => update({ proxyUrl: e.target.value || null })}
@@ -232,14 +233,14 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 />
                 {settings.proxyUrl && (
                   <div className="flex gap-2">
-                    <input
+                    <Input
                       type="text"
                       value={settings.proxyUsername ?? ""}
                       onChange={(e) => update({ proxyUsername: e.target.value || null })}
                       placeholder={t("settings.proxyUsername")}
                       className="flex-1 rounded bg-[var(--color-elevated)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-dimmed)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
                     />
-                    <input
+                    <Input
                       type="password"
                       value={settings.proxyPassword ?? ""}
                       onChange={(e) => update({ proxyPassword: e.target.value || null })}
@@ -302,7 +303,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                   <label className="mb-2 block text-sm text-[var(--color-text-secondary)]">
                     {t("settings.pfxPassphrase")}
                   </label>
-                  <input
+                  <Input
                     type="password"
                     value={settings.clientCertPassphrase ?? ""}
                     onChange={(e) => update({ clientCertPassphrase: e.target.value || null })}
@@ -323,7 +324,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                   <label className="mb-1 block text-sm text-[var(--color-text-secondary)]">
                     API Endpoint
                   </label>
-                  <input
+                  <Input
                     type="text"
                     value={settings.aiEndpoint ?? ""}
                     onChange={(e) => update({ aiEndpoint: e.target.value.trim() || null })}
@@ -338,7 +339,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                   <label className="mb-1 block text-sm text-[var(--color-text-secondary)]">
                     API Key
                   </label>
-                  <input
+                  <Input
                     type="password"
                     value={settings.aiApiKey ?? ""}
                     onChange={(e) => update({ aiApiKey: e.target.value || null })}
@@ -350,7 +351,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                   <label className="mb-1 block text-sm text-[var(--color-text-secondary)]">
                     Model
                   </label>
-                  <input
+                  <Input
                     type="text"
                     value={settings.aiModel ?? ""}
                     onChange={(e) => update({ aiModel: e.target.value || null })}
@@ -706,7 +707,7 @@ function FilePathInput({
 
   return (
     <div className="flex gap-2">
-      <input
+      <Input
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}

--- a/apps/desktop/src/components/socketio/socketio-view.tsx
+++ b/apps/desktop/src/components/socketio/socketio-view.tsx
@@ -14,6 +14,8 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { Input } from "@/components/ui/input";
+import { TextArea } from "@/components/ui/textarea";
 
 export function SocketIoView() {
   const tab = useActiveTab();
@@ -79,7 +81,7 @@ export function SocketIoView() {
         <span className="rounded bg-pink-500/15 px-1.5 py-0.5 text-[10px] font-bold text-pink-400">
           SIO
         </span>
-        <input
+        <Input
           type="text"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
@@ -89,7 +91,7 @@ export function SocketIoView() {
         />
         <div className="flex items-center gap-1">
           <span className="text-xs text-[var(--color-text-dimmed)]">ns:</span>
-          <input
+          <Input
             type="text"
             value={namespace}
             onChange={(e) => setNamespace(e.target.value)}
@@ -190,7 +192,7 @@ export function SocketIoView() {
           Emit Event
         </div>
         <div className="flex items-center gap-1.5 mb-1.5">
-          <input
+          <Input
             type="text"
             value={eventName}
             onChange={(e) => setEventName(e.target.value)}
@@ -200,7 +202,7 @@ export function SocketIoView() {
           />
         </div>
         <div className="flex items-end gap-1.5">
-          <textarea
+          <TextArea
             value={eventArgs}
             onChange={(e) => setEventArgs(e.target.value)}
             placeholder='Arguments (JSON) e.g. "hello" or {"msg": "hi"} or ["a", 1]'
@@ -236,7 +238,7 @@ export function SocketIoView() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <input
+          <Input
             type="text"
             value={listenFilter}
             onChange={(e) => setListenFilter(e.target.value)}

--- a/apps/desktop/src/components/sse/sse-view.tsx
+++ b/apps/desktop/src/components/sse/sse-view.tsx
@@ -7,6 +7,7 @@ import { KeyValueEditor } from "@/components/request/key-value-editor";
 import { Plug, Unplug, Trash2, ChevronDown, ChevronRight } from "lucide-react";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { UrlBar } from "@/components/request/url-bar";
+import { Input } from "@/components/ui/input";
 
 export function SSEView() {
   const { t } = useTranslation();
@@ -131,7 +132,7 @@ export function SSEView() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <input
+          <Input
             type="text"
             value={filter}
             onChange={(e) => setFilter(e.target.value)}

--- a/apps/desktop/src/components/ui/input.tsx
+++ b/apps/desktop/src/components/ui/input.tsx
@@ -1,0 +1,33 @@
+import { forwardRef } from "react";
+
+/**
+ * Text input with auto-capitalization and auto-correction disabled by default.
+ *
+ * On macOS (WKWebView) native inputs auto-capitalize the first letter and
+ * auto-correct what the user types, which corrupts technical values like
+ * variable keys, headers, and URLs. These defaults turn that behavior off
+ * while still allowing any prop to be overridden by the caller.
+ */
+export const Input = forwardRef<HTMLInputElement, React.ComponentPropsWithoutRef<"input">>(
+  (
+    {
+      autoCapitalize = "off",
+      autoCorrect = "off",
+      autoComplete = "off",
+      spellCheck = false,
+      ...props
+    },
+    ref,
+  ) => (
+    <input
+      ref={ref}
+      autoCapitalize={autoCapitalize}
+      autoCorrect={autoCorrect}
+      autoComplete={autoComplete}
+      spellCheck={spellCheck}
+      {...props}
+    />
+  ),
+);
+
+Input.displayName = "Input";

--- a/apps/desktop/src/components/ui/textarea.tsx
+++ b/apps/desktop/src/components/ui/textarea.tsx
@@ -1,0 +1,35 @@
+import { forwardRef } from "react";
+
+/**
+ * Textarea with auto-capitalization and auto-correction disabled by default.
+ *
+ * Same rationale as {@link Input}: on macOS (WKWebView) textareas auto-correct
+ * and auto-capitalize technical content (request bodies, payloads, tokens).
+ * Callers that hold natural-language text can re-enable these via props.
+ */
+export const TextArea = forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentPropsWithoutRef<"textarea">
+>(
+  (
+    {
+      autoCapitalize = "off",
+      autoCorrect = "off",
+      autoComplete = "off",
+      spellCheck = false,
+      ...props
+    },
+    ref,
+  ) => (
+    <textarea
+      ref={ref}
+      autoCapitalize={autoCapitalize}
+      autoCorrect={autoCorrect}
+      autoComplete={autoComplete}
+      spellCheck={spellCheck}
+      {...props}
+    />
+  ),
+);
+
+TextArea.displayName = "TextArea";

--- a/apps/desktop/src/components/websocket/websocket-view.tsx
+++ b/apps/desktop/src/components/websocket/websocket-view.tsx
@@ -6,6 +6,7 @@ import { KeyValueEditor } from "@/components/request/key-value-editor";
 import { Send, Plug, Unplug, Trash2, ArrowUp, ArrowDown, ChevronDown, ChevronRight } from "lucide-react";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { UrlBar } from "@/components/request/url-bar";
+import { TextArea } from "@/components/ui/textarea";
 
 export function WebSocketView() {
   const tab = useActiveTab();
@@ -122,7 +123,7 @@ export function WebSocketView() {
 
       {/* Message input */}
       <div className="flex items-end gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2">
-        <textarea
+        <TextArea
           value={messageInput}
           onChange={(e) => setMessageInput(e.target.value)}
           placeholder={status === "connected" ? "Type a message..." : "Connect first to send messages"}


### PR DESCRIPTION
Fixes #86

## Summary
- On macOS (WKWebView), native inputs auto-capitalize the first letter and auto-correct typed text, corrupting technical values such as variable **keys**, headers, query params, and URLs.
- Adds shared `Input` and `TextArea` UI components that bake in `autoCapitalize`/`autoCorrect`/`autoComplete` off and `spellCheck={false}` (all overridable via props), then migrates the desktop data-entry fields to use them.
- The AI assistant chat textarea keeps natural-language assistance (`autoCapitalize="sentences"`, `autoCorrect="on"`, `spellCheck`) since that text is prose, not technical input.

## Changes
| File | Change |
|------|--------|
| `apps/desktop/src/components/ui/input.tsx` | New shared `Input` wrapper with auto-correct/capitalize disabled by default |
| `apps/desktop/src/components/ui/textarea.tsx` | New shared `TextArea` wrapper, same defaults |
| `apps/desktop/src/components/**` (21 files) | Migrate raw text `<input>`/`<textarea>` data-entry fields to the shared components |

## Test Plan
- [x] `tsc -b` typecheck passes clean
- [x] `eslint` clean on the new components
- [ ] Manual: on macOS, typing a lowercase variable key/header/URL no longer auto-capitalizes

## Notes
- Checkboxes, radios, file and range inputs are intentionally left as raw elements.