### PR TITLE
fix(http): strip JSONC comments from JSON bodies before sending

### DIFF
--- a/apps/cli/src/jsonc.rs
+++ b/apps/cli/src/jsonc.rs
@@ -1,0 +1,146 @@
+//! Strip JSONC-style comments from a JSON body before sending.
+//!
+//! Users write request bodies with `//` line comments and `/* */` block
+//! comments (JSONC). Servers expect strict JSON, so comments must be removed
+//! before the body is sent. Stripping is string-aware: comment markers that
+//! appear inside a JSON string value are left untouched.
+
+/// Remove `//` line comments and `/* */` block comments from a JSON string.
+///
+/// Comment markers inside string literals are preserved. Characters that are
+/// not comments are copied verbatim, so whitespace and formatting outside of
+/// removed comments are unchanged.
+pub fn strip_json_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            // Inside a string literal: copy through to the closing quote,
+            // honouring backslash escapes so `\"` does not end the string.
+            '"' => {
+                out.push(c);
+                while let Some(sc) = chars.next() {
+                    out.push(sc);
+                    if sc == '\\' {
+                        if let Some(escaped) = chars.next() {
+                            out.push(escaped);
+                        }
+                    } else if sc == '"' {
+                        break;
+                    }
+                }
+            }
+            // Comment markers, only when not inside a string.
+            '/' => match chars.peek() {
+                Some('/') => {
+                    chars.next();
+                    // Drop everything up to (but not including) the newline,
+                    // so line structure is preserved.
+                    while let Some(&lc) = chars.peek() {
+                        if lc == '\n' {
+                            break;
+                        }
+                        chars.next();
+                    }
+                }
+                Some('*') => {
+                    chars.next();
+                    let mut prev = '\0';
+                    for bc in chars.by_ref() {
+                        if prev == '*' && bc == '/' {
+                            break;
+                        }
+                        prev = bc;
+                    }
+                }
+                // A lone `/` is not a comment; keep it.
+                _ => out.push(c),
+            },
+            _ => out.push(c),
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parses(s: &str) -> bool {
+        serde_json::from_str::<serde_json::Value>(s).is_ok()
+    }
+
+    #[test]
+    fn strips_leading_line_comment() {
+        // The bug from issue #85: a comment before the JSON broke the request.
+        let input = "// { \"test\": \"test2\"}\n{ \"test\":\"test\"}";
+        let out = strip_json_comments(input);
+        assert!(
+            parses(&out),
+            "stripped output should be valid JSON: {out:?}"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_line_comment() {
+        let input = "{ \"test\":\"test\"}\n// { \"test\": \"test2\"}";
+        let out = strip_json_comments(input);
+        assert!(
+            parses(&out),
+            "stripped output should be valid JSON: {out:?}"
+        );
+    }
+
+    #[test]
+    fn strips_block_comment() {
+        let input = "{ /* inline */ \"test\": \"test\" }";
+        let out = strip_json_comments(input);
+        assert!(
+            parses(&out),
+            "stripped output should be valid JSON: {out:?}"
+        );
+    }
+
+    #[test]
+    fn preserves_double_slash_inside_string() {
+        let input = "{ \"url\": \"https://example.com\" }";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["url"], "https://example.com");
+    }
+
+    #[test]
+    fn preserves_block_marker_inside_string() {
+        let input = "{ \"glob\": \"/*.json\" }";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["glob"], "/*.json");
+    }
+
+    #[test]
+    fn preserves_escaped_quote_inside_string() {
+        let input = "{ \"q\": \"a \\\" // not a comment\" }";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["q"], "a \" // not a comment");
+    }
+
+    #[test]
+    fn preserves_escaped_backslash_before_closing_quote() {
+        // The value is `val\` — an escaped backslash right before the closing
+        // quote. The string-end detection must not be fooled into running past
+        // it and eating the rest of the JSON.
+        let input = "{\"k\": \"val\\\\\"}";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["k"], "val\\");
+    }
+
+    #[test]
+    fn leaves_plain_json_untouched() {
+        let input = "{\"a\":1,\"b\":[2,3]}";
+        assert_eq!(strip_json_comments(input), input);
+    }
+}

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod collection;
 mod import_export;
 mod interpolation;
+mod jsonc;
 mod models;
 mod reporter;
 mod runner;

--- a/apps/cli/src/runner.rs
+++ b/apps/cli/src/runner.rs
@@ -6,6 +6,7 @@ use colored::Colorize;
 
 use crate::collection;
 use crate::interpolation;
+use crate::jsonc;
 use crate::models::*;
 
 /// Run a collection and return a summary.
@@ -180,7 +181,7 @@ async fn run_single_request(
             "json" => {
                 builder = builder
                     .header("Content-Type", "application/json")
-                    .body(content);
+                    .body(jsonc::strip_json_comments(&content));
             }
             "xml" => {
                 builder = builder

--- a/apps/desktop/src-tauri/src/http/jsonc.rs
+++ b/apps/desktop/src-tauri/src/http/jsonc.rs
@@ -1,0 +1,146 @@
+//! Strip JSONC-style comments from a JSON body before sending.
+//!
+//! Users write request bodies with `//` line comments and `/* */` block
+//! comments (JSONC). Servers expect strict JSON, so comments must be removed
+//! before the body is sent. Stripping is string-aware: comment markers that
+//! appear inside a JSON string value are left untouched.
+
+/// Remove `//` line comments and `/* */` block comments from a JSON string.
+///
+/// Comment markers inside string literals are preserved. Characters that are
+/// not comments are copied verbatim, so whitespace and formatting outside of
+/// removed comments are unchanged.
+pub fn strip_json_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            // Inside a string literal: copy through to the closing quote,
+            // honouring backslash escapes so `\"` does not end the string.
+            '"' => {
+                out.push(c);
+                while let Some(sc) = chars.next() {
+                    out.push(sc);
+                    if sc == '\\' {
+                        if let Some(escaped) = chars.next() {
+                            out.push(escaped);
+                        }
+                    } else if sc == '"' {
+                        break;
+                    }
+                }
+            }
+            // Comment markers, only when not inside a string.
+            '/' => match chars.peek() {
+                Some('/') => {
+                    chars.next();
+                    // Drop everything up to (but not including) the newline,
+                    // so line structure is preserved.
+                    while let Some(&lc) = chars.peek() {
+                        if lc == '\n' {
+                            break;
+                        }
+                        chars.next();
+                    }
+                }
+                Some('*') => {
+                    chars.next();
+                    let mut prev = '\0';
+                    for bc in chars.by_ref() {
+                        if prev == '*' && bc == '/' {
+                            break;
+                        }
+                        prev = bc;
+                    }
+                }
+                // A lone `/` is not a comment; keep it.
+                _ => out.push(c),
+            },
+            _ => out.push(c),
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parses(s: &str) -> bool {
+        serde_json::from_str::<serde_json::Value>(s).is_ok()
+    }
+
+    #[test]
+    fn strips_leading_line_comment() {
+        // The bug from issue #85: a comment before the JSON broke the request.
+        let input = "// { \"test\": \"test2\"}\n{ \"test\":\"test\"}";
+        let out = strip_json_comments(input);
+        assert!(
+            parses(&out),
+            "stripped output should be valid JSON: {out:?}"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_line_comment() {
+        let input = "{ \"test\":\"test\"}\n// { \"test\": \"test2\"}";
+        let out = strip_json_comments(input);
+        assert!(
+            parses(&out),
+            "stripped output should be valid JSON: {out:?}"
+        );
+    }
+
+    #[test]
+    fn strips_block_comment() {
+        let input = "{ /* inline */ \"test\": \"test\" }";
+        let out = strip_json_comments(input);
+        assert!(
+            parses(&out),
+            "stripped output should be valid JSON: {out:?}"
+        );
+    }
+
+    #[test]
+    fn preserves_double_slash_inside_string() {
+        let input = "{ \"url\": \"https://example.com\" }";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["url"], "https://example.com");
+    }
+
+    #[test]
+    fn preserves_block_marker_inside_string() {
+        let input = "{ \"glob\": \"/*.json\" }";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["glob"], "/*.json");
+    }
+
+    #[test]
+    fn preserves_escaped_quote_inside_string() {
+        let input = "{ \"q\": \"a \\\" // not a comment\" }";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["q"], "a \" // not a comment");
+    }
+
+    #[test]
+    fn preserves_escaped_backslash_before_closing_quote() {
+        // The value is `val\` — an escaped backslash right before the closing
+        // quote. The string-end detection must not be fooled into running past
+        // it and eating the rest of the JSON.
+        let input = "{\"k\": \"val\\\\\"}";
+        let out = strip_json_comments(input);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["k"], "val\\");
+    }
+
+    #[test]
+    fn leaves_plain_json_untouched() {
+        let input = "{\"a\":1,\"b\":[2,3]}";
+        assert_eq!(strip_json_comments(input), input);
+    }
+}

--- a/apps/desktop/src-tauri/src/http/mod.rs
+++ b/apps/desktop/src-tauri/src/http/mod.rs
@@ -4,5 +4,6 @@ pub mod cookies;
 pub mod curl;
 pub mod error_classifier;
 pub mod interpolation;
+pub mod jsonc;
 pub mod request_builder;
 pub mod response_parser;

--- a/apps/desktop/src-tauri/src/http/request_builder.rs
+++ b/apps/desktop/src-tauri/src/http/request_builder.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use url::Url;
 
 use crate::http::auth_handlers;
+use crate::http::jsonc;
 use crate::models::auth::{ApiKeyLocation, AuthConfig};
 use crate::models::error::HttpEngineError;
 use crate::models::request::{BodyType, KeyValuePair, RequestBody, SendRequestParams};
@@ -296,7 +297,7 @@ fn apply_body(
     match body.body_type {
         BodyType::Json => Ok(builder
             .header("Content-Type", "application/json")
-            .body(body.content.clone())),
+            .body(jsonc::strip_json_comments(&body.content))),
         BodyType::Xml => Ok(builder
             .header("Content-Type", "application/xml")
             .body(body.content.clone())),

--- a/apps/desktop/src/components/ui/code-editor.tsx
+++ b/apps/desktop/src/components/ui/code-editor.tsx
@@ -6,7 +6,23 @@ import { useResolvedTheme } from "@/hooks/use-theme";
 // Configure Monaco to use the local monaco-editor package instead of fetching from CDN.
 // The vite-plugin-monaco-editor handles bundling workers automatically.
 import * as monacoEditor from "monaco-editor";
+// `monaco.languages.json` is a deprecated stub in monaco 0.55's public types,
+// so the JSON language defaults are reached through the contribution module.
+// Its bundled `.d.ts` is empty, hence the local typing of the bits we use.
+import * as jsonContribution from "monaco-editor/esm/vs/language/json/monaco.contribution.js";
 loader.config({ monaco: monacoEditor });
+
+type JsonDiagnosticsOptions = {
+  allowComments?: boolean;
+  comments?: "error" | "warning" | "ignore";
+} & Record<string, unknown>;
+
+const { jsonDefaults: jsonLanguageDefaults } = jsonContribution as unknown as {
+  jsonDefaults: {
+    readonly diagnosticsOptions: JsonDiagnosticsOptions;
+    setDiagnosticsOptions(options: JsonDiagnosticsOptions): void;
+  };
+};
 
 // ApiArk light theme
 const APIARK_LIGHT: Monaco.editor.IStandaloneThemeData = {
@@ -85,6 +101,7 @@ const APIARK_BLACK: Monaco.editor.IStandaloneThemeData = {
 
 let themesRegistered = false;
 let graphqlRegistered = false;
+let jsonDiagnosticsConfigured = false;
 
 function registerThemes(monaco: typeof Monaco) {
   if (themesRegistered) return;
@@ -92,6 +109,20 @@ function registerThemes(monaco: typeof Monaco) {
   monaco.editor.defineTheme("apiark-dark", APIARK_DARK);
   monaco.editor.defineTheme("apiark-black", APIARK_BLACK);
   themesRegistered = true;
+}
+
+// JSONC comments are stripped from the body before the request is sent, so
+// they are valid input in the editor. Tell Monaco's JSON language service not
+// to flag them as errors (the red squiggle), while keeping the rest of JSON
+// validation intact.
+function configureJsonDiagnostics() {
+  if (jsonDiagnosticsConfigured) return;
+  jsonLanguageDefaults.setDiagnosticsOptions({
+    ...jsonLanguageDefaults.diagnosticsOptions,
+    allowComments: true,
+    comments: "ignore",
+  });
+  jsonDiagnosticsConfigured = true;
 }
 
 function registerGraphQL(monaco: typeof Monaco) {
@@ -189,6 +220,7 @@ export function CodeEditor({
     monacoRef.current = monaco;
     registerGraphQL(monaco);
     registerThemes(monaco);
+    configureJsonDiagnostics();
     monaco.editor.setTheme(monacoTheme);
     setContentLeft(editor.getLayoutInfo().contentLeft);
     editor.onDidLayoutChange((layout) => {


### PR DESCRIPTION
Closes #85

## Summary

- JSON request bodies that contain JSONC-style comments (`// ...` and `/* */`) were sent to the server verbatim.
- A *trailing* comment happened to work when the server tolerated trailing data, but a *leading* comment made the body start with `//`, so JSON parsing failed immediately.
- This strips comments (string-aware) before the body is sent, in both the desktop backend and the CLI.

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src-tauri/src/http/jsonc.rs` | New `strip_json_comments` (string-aware: preserves `//` and `/*` inside JSON strings, honors `\` escapes) + unit tests |
| `apps/desktop/src-tauri/src/http/mod.rs` | Register `jsonc` module |
| `apps/desktop/src-tauri/src/http/request_builder.rs` | Strip comments for `BodyType::Json` before sending |
| `apps/cli/src/jsonc.rs` | Same helper + tests (no shared crate between desktop and CLI) |
| `apps/cli/src/main.rs` | Register `jsonc` module |
| `apps/cli/src/runner.rs` | Strip comments for json bodies before sending |

## Test Plan

- [x] `cargo test` — 8 unit tests per crate, all passing (leading/trailing line comments, block comments, markers preserved inside strings, escaped quote/backslash before closing quote, plain JSON untouched)
- [x] `cargo clippy` clean, `cargo fmt` applied