### PR TITLE
fix(variables): recognize hyphens and dots in {{variable}} names

### DIFF
--- a/apps/desktop/src/components/request/url-bar.tsx
+++ b/apps/desktop/src/components/request/url-bar.tsx
@@ -7,6 +7,7 @@ import { Loader2, Send, AlertCircle, Check } from "lucide-react";
 import * as Popover from "@radix-ui/react-popover";
 import { HintTooltip } from "@/components/ui/hint-tooltip";
 import { saveEnvironment } from "@/lib/tauri-api";
+import { variableRegex } from "@/lib/variables";
 
 const METHODS: HttpMethod[] = [
   "GET",
@@ -52,7 +53,7 @@ function extractVariableRefs(tab: {
     tab.body.content,
   ].join(" ");
 
-  const matches = text.match(/\{\{([\w$]+)\}\}/g);
+  const matches = text.match(variableRegex());
   if (!matches) return [];
   return [...new Set(matches.map((m) => m.slice(2, -2)))];
 }
@@ -60,7 +61,7 @@ function extractVariableRefs(tab: {
 /** Split a URL string into segments of plain text and {{variable}} references */
 function splitUrlSegments(url: string): { type: "text" | "var"; value: string }[] {
   const segments: { type: "text" | "var"; value: string }[] = [];
-  const regex = /\{\{([\w$]+)\}\}/g;
+  const regex = variableRegex();
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 

--- a/apps/desktop/src/components/response/code-generation-panel.tsx
+++ b/apps/desktop/src/components/response/code-generation-panel.tsx
@@ -4,6 +4,7 @@ import { Copy, Check } from "lucide-react";
 import { useActiveTab } from "@/stores/tab-store";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { generateCurl, generateJsFetch, generatePythonRequests } from "@/lib/code-generators";
+import { variableRegex } from "@/lib/variables";
 import type { Tab } from "@apiark/types";
 
 type Language = "curl" | "javascript" | "python";
@@ -16,7 +17,7 @@ const LANGUAGES: { value: Language; label: string }[] = [
 
 /** Replace all {{varName}} in a string with resolved values */
 function resolveVariables(str: string, vars: Record<string, string>): string {
-  return str.replace(/\{\{([\w$]+)\}\}/g, (_, name) => vars[name] ?? `{{${name}}}`);
+  return str.replace(variableRegex(), (_, name) => vars[name] ?? `{{${name}}}`);
 }
 
 /** Replace :paramName path variables in a URL with their values */

--- a/apps/desktop/src/lib/variables.ts
+++ b/apps/desktop/src/lib/variables.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared definition of what a `{{variable}}` reference looks like in the UI.
+ *
+ * The backend interpolator matches `{{([^}]+)}}` (see
+ * `apps/desktop/src-tauri/src/http/interpolation.rs` and
+ * `apps/cli/src/interpolation.rs`), so it resolves names containing hyphens,
+ * dots, etc. — e.g. `{{bff-host}}` or `{{api.key}}`. The frontend previously
+ * used `[\w$]+`, which silently dropped those names from highlighting,
+ * extraction, hover preview and click-to-edit even though the request itself
+ * resolved them correctly. Keep this pattern in one place so the frontend
+ * stays in sync with what the backend accepts.
+ */
+export const VARIABLE_NAME_PATTERN = String.raw`[\w$.-]+`;
+
+/**
+ * Returns a fresh global RegExp matching `{{name}}` references.
+ *
+ * A new instance is returned on every call because the `g` flag makes
+ * `RegExp` stateful (`lastIndex`); sharing a single instance across callers
+ * that use `.exec()` in a loop would corrupt their iteration.
+ */
+export function variableRegex(): RegExp {
+  return new RegExp(String.raw`\{\{(${VARIABLE_NAME_PATTERN})\}\}`, "g");
+}


### PR DESCRIPTION
Closes #98

## Problem

A variable like `{{bff-host}}` (hyphen) or `{{api.key}}` (dot) **resolves correctly when the request is sent**, but the UI treats it as plain text: no highlight, no chip, no hover preview, no click-to-edit, and it's skipped during code generation.

## Cause

The frontend matched variable names with `[\w$]+` (word chars + `$`), while the backend interpolator (Rust) matches `{{([^}]+)}}`:

- `apps/desktop/src-tauri/src/http/interpolation.rs`
- `apps/cli/src/interpolation.rs`

So the backend resolves `bff-host` while the frontend pretends it isn't a variable. The stricter pattern was also duplicated in three places, which is how they drifted apart.

## Change

- New `apps/desktop/src/lib/variables.ts` with a single `variableRegex()` (pattern `[\w$.-]+`) and a documented note tying it to the backend.
- Use it in `extractVariableRefs`, `splitUrlSegments` (url-bar) and `resolveVariables` (code-generation-panel).

This restores highlighting, extraction, hover preview, click-to-edit and code generation for hyphenated/dotted names. Full `[^}]+` parity (including whitespace) is intentionally left out to avoid trimming edge cases; `[\w$.-]+` covers the realistic names.

| File | Change |
|------|--------|
| `apps/desktop/src/lib/variables.ts` | New shared `{{variable}}` matcher |
| `apps/desktop/src/components/request/url-bar.tsx` | Use shared matcher for extract + segment split |
| `apps/desktop/src/components/response/code-generation-panel.tsx` | Use shared matcher for codegen substitution |

## Test plan

- [x] `tsc -b` clean
- [x] `{{bff-host}}` in the URL bar now renders as a chip with hover preview and click-to-edit
- [x] Existing `{{baseUrl}}`-style names still work