### PR TITLE
feat(grpc): implement server reflection to discover services

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tonic",
+ "tonic-build",
  "tower 0.5.3",
  "tracing",
  "tracing-appender",
@@ -1539,6 +1540,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -3098,6 +3105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,6 +3648,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,6 +4104,26 @@ checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
 ]
 
 [[package]]
@@ -6484,6 +6527,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -15,6 +15,8 @@ path = "src/main.rs"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+tonic-build = "0.12"
+protox = "0.7"
 
 [dependencies]
 tauri = { version = "2", features = [] }

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,16 @@
 fn main() {
-    tauri_build::build()
+    // Compile the gRPC server reflection proto into a tonic client.
+    // We parse the .proto with protox (pure-Rust) instead of relying on a
+    // system `protoc` binary, then feed the FileDescriptorSet to tonic-build.
+    let fds = protox::compile(["proto/reflection.proto"], ["proto"])
+        .expect("failed to compile reflection.proto with protox");
+
+    tonic_build::configure()
+        .build_server(false)
+        .compile_fds(fds)
+        .expect("failed to generate reflection client");
+
+    println!("cargo:rerun-if-changed=proto/reflection.proto");
+
+    tauri_build::build();
 }

--- a/apps/desktop/src-tauri/proto/reflection.proto
+++ b/apps/desktop/src-tauri/proto/reflection.proto
@@ -1,0 +1,115 @@
+// gRPC Server Reflection Protocol (v1).
+// Source: https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1/reflection.proto
+syntax = "proto3";
+
+package grpc.reflection.v1;
+
+// Service exported by server reflection. A more complete description of how
+// server reflection works can be found at
+// https://github.com/grpc/grpc/blob/master/doc/server-reflection.md
+service ServerReflection {
+  // The reflection service is structured as a bidirectional stream, ensuring
+  // all related requests go to a single server.
+  rpc ServerReflectionInfo(stream ServerReflectionRequest)
+      returns (stream ServerReflectionResponse);
+}
+
+// The message sent by the client when calling ServerReflectionInfo method.
+message ServerReflectionRequest {
+  string host = 1;
+  // To use reflection service, the client should set one of the following
+  // fields in message_request. The server distinguishes requests by their
+  // defined field and then handles them using corresponding methods.
+  oneof message_request {
+    // Find a proto file by the file name.
+    string file_by_filename = 3;
+
+    // Find the proto file that declares the given fully-qualified symbol name.
+    // This field should be a fully-qualified symbol name
+    // (e.g. <package>.<service>[.<method>] or <package>.<type>).
+    string file_containing_symbol = 4;
+
+    // Find the proto file which defines an extension extending the given
+    // message type with the given field number.
+    ExtensionRequest file_containing_extension = 5;
+
+    // Finds the tag numbers used by all known extensions of the given message
+    // type, and appends them to ExtensionNumberResponse in an undefined order.
+    string all_extension_numbers_of_type = 6;
+
+    // List the full names of registered services. The content will not be
+    // checked.
+    string list_services = 7;
+  }
+}
+
+// The type name and extension number sent by the client when requesting
+// file_containing_extension.
+message ExtensionRequest {
+  // Fully-qualified type name. The format should be <package>.<type>
+  string containing_type = 1;
+  int32 extension_number = 2;
+}
+
+// The message sent by the server to answer ServerReflectionInfo method.
+message ServerReflectionResponse {
+  string valid_host = 1;
+  ServerReflectionRequest original_request = 2;
+  // The server sets one of the following fields according to the message_request
+  // in the request.
+  oneof message_response {
+    // This message is used to answer file_by_filename, file_containing_symbol,
+    // file_containing_extension requests with transitive dependencies.
+    FileDescriptorResponse file_descriptor_response = 4;
+
+    // This message is used to answer all_extension_numbers_of_type requests.
+    ExtensionNumberResponse all_extension_numbers_response = 5;
+
+    // This message is used to answer list_services requests.
+    ListServiceResponse list_services_response = 6;
+
+    // This message is used when an error occurs.
+    ErrorResponse error_response = 7;
+  }
+}
+
+// Serialized FileDescriptorProto messages sent by the server answering
+// a file_by_filename, file_containing_symbol, or file_containing_extension
+// request.
+message FileDescriptorResponse {
+  // Serialized FileDescriptorProto messages. We avoid taking a dependency on
+  // descriptor.proto, which uses proto2 only features, by making them opaque
+  // bytes instead.
+  repeated bytes file_descriptor_proto = 1;
+}
+
+// A list of extension numbers sent by the server answering
+// all_extension_numbers_of_type request.
+message ExtensionNumberResponse {
+  // Full name of the base type, including the package name. The format
+  // is <package>.<type>
+  string base_type_name = 1;
+  repeated int32 extension_number = 2;
+}
+
+// A list of ServiceResponse sent by the server answering list_services request.
+message ListServiceResponse {
+  // The information of each service may be expanded in the future, so we use
+  // ServiceResponse message to encapsulate it.
+  repeated ServiceResponse service = 1;
+}
+
+// The information of a single service used by ListServiceResponse to answer
+// list_services request.
+message ServiceResponse {
+  // Full name of a registered service, including its package name. The format
+  // is <package>.<service>
+  string name = 1;
+}
+
+// The error code and error message sent by the server when an error occurs.
+message ErrorResponse {
+  // This field uses the error codes defined in grpc::StatusCode.
+  int32 error_code = 1;
+  string error_message = 2;
+}

--- a/apps/desktop/src-tauri/src/commands/collection.rs
+++ b/apps/desktop/src-tauri/src/commands/collection.rs
@@ -91,6 +91,7 @@ pub async fn create_request(
         pre_request_script: None,
         post_response_script: None,
         cookies: None,
+        grpc: None,
     };
     let path = collection::create_request_file(dir_path, &filename, &request)?;
     Ok(path.to_string_lossy().to_string())

--- a/apps/desktop/src-tauri/src/commands/grpc.rs
+++ b/apps/desktop/src-tauri/src/commands/grpc.rs
@@ -1,7 +1,7 @@
 use tauri::{AppHandle, State};
 
 use crate::grpc::client::GrpcManager;
-use crate::grpc::proto_parser;
+use crate::grpc::{proto_parser, reflection};
 use crate::grpc::{GrpcMetadata, GrpcResponse, GrpcServiceInfo};
 
 #[tauri::command]
@@ -11,6 +11,17 @@ pub async fn grpc_load_proto(
     grpc: State<'_, GrpcManager>,
 ) -> Result<Vec<GrpcServiceInfo>, String> {
     let (services, pool) = proto_parser::parse_proto_file(&proto_path)?;
+    grpc.store_pool(&connection_id, pool)?;
+    Ok(services)
+}
+
+#[tauri::command]
+pub async fn grpc_reflect_services(
+    connection_id: String,
+    address: String,
+    grpc: State<'_, GrpcManager>,
+) -> Result<Vec<GrpcServiceInfo>, String> {
+    let (services, pool) = reflection::reflect_services(grpc.inner(), &address).await?;
     grpc.store_pool(&connection_id, pool)?;
     Ok(services)
 }

--- a/apps/desktop/src-tauri/src/grpc/client.rs
+++ b/apps/desktop/src-tauri/src/grpc/client.rs
@@ -92,7 +92,7 @@ impl GrpcManager {
     }
 
     /// Get or create a channel to the given address
-    async fn get_channel(&self, address: &str) -> Result<Channel, String> {
+    pub(crate) async fn get_channel(&self, address: &str) -> Result<Channel, String> {
         {
             let channels = self
                 .channels
@@ -105,6 +105,7 @@ impl GrpcManager {
 
         let channel = Channel::from_shared(address.to_string())
             .map_err(|e| format!("Invalid gRPC address: {e}"))?
+            .connect_timeout(std::time::Duration::from_secs(10))
             .connect()
             .await
             .map_err(|e| format!("Failed to connect to gRPC server: {e}"))?;
@@ -132,7 +133,8 @@ impl GrpcManager {
         let pool = {
             let pools = self.pools.lock().map_err(|e| format!("Lock error: {e}"))?;
             pools.get(connection_id).cloned().ok_or_else(|| {
-                "No proto schema loaded for this connection. Load a .proto file first.".to_string()
+                "No schema loaded for this connection. Use 'Reflect' or load a .proto file."
+                    .to_string()
             })?
         };
 
@@ -149,7 +151,7 @@ impl GrpcManager {
 
         let input_desc = method_desc.input();
 
-        // Parse JSON to DynamicMessage
+        // Parse JSON to DynamicMessage.
         let json_value: serde_json::Value =
             serde_json::from_str(request_json).map_err(|e| format!("Invalid JSON: {e}"))?;
         let request_msg = json_to_dynamic_message(&input_desc, &json_value)?;
@@ -585,10 +587,10 @@ impl GrpcManager {
     > {
         let pool = {
             let pools = self.pools.lock().map_err(|e| format!("Lock error: {e}"))?;
-            pools
-                .get(connection_id)
-                .cloned()
-                .ok_or_else(|| "No proto schema loaded. Load a .proto file first.".to_string())?
+            pools.get(connection_id).cloned().ok_or_else(|| {
+                "No schema loaded for this connection. Use 'Reflect' or load a .proto file."
+                    .to_string()
+            })?
         };
         let svc_desc = pool
             .services()

--- a/apps/desktop/src-tauri/src/grpc/mod.rs
+++ b/apps/desktop/src-tauri/src/grpc/mod.rs
@@ -1,9 +1,12 @@
 pub mod client;
 pub mod proto_parser;
-#[allow(dead_code, unused_imports, unused_variables)]
 pub mod reflection;
 
+use std::collections::HashSet;
+
+use prost_reflect::{Kind, MessageDescriptor};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,6 +24,69 @@ pub struct GrpcMethodInfo {
     pub input_type: String,
     pub output_type: String,
     pub call_type: GrpcCallType,
+    /// Example request body (JSON) with zero values for every field of the
+    /// input message, generated from the descriptor so the editor can be
+    /// pre-filled instead of showing an empty `{}`.
+    pub example_json: String,
+}
+
+/// Build an example JSON object for a message descriptor, using zero values for
+/// every field (`""` for strings, `0` for numbers, `false` for bools, `[]` for
+/// repeated, `{}` for maps, the first variant for enums, and a recursively
+/// generated object for nested messages).
+///
+/// `visited` guards against infinite recursion on self-referential or mutually
+/// recursive messages: a message already on the current path collapses to `{}`.
+pub fn generate_example_json(
+    desc: &MessageDescriptor,
+    visited: &mut HashSet<String>,
+) -> serde_json::Value {
+    if !visited.insert(desc.full_name().to_string()) {
+        // Cycle detected — stop recursing and emit an empty object.
+        return serde_json::Value::Object(Default::default());
+    }
+
+    let mut map = serde_json::Map::new();
+    for field in desc.fields() {
+        let value = if field.is_list() {
+            serde_json::Value::Array(vec![])
+        } else if field.is_map() {
+            serde_json::Value::Object(Default::default())
+        } else {
+            match field.kind() {
+                Kind::String | Kind::Bytes => json!(""),
+                Kind::Bool => json!(false),
+                Kind::Float | Kind::Double => json!(0.0),
+                Kind::Int32
+                | Kind::Int64
+                | Kind::Uint32
+                | Kind::Uint64
+                | Kind::Sint32
+                | Kind::Sint64
+                | Kind::Fixed32
+                | Kind::Fixed64
+                | Kind::Sfixed32
+                | Kind::Sfixed64 => json!(0),
+                Kind::Enum(e) => e
+                    .values()
+                    .next()
+                    .map(|v| json!(v.name()))
+                    .unwrap_or_else(|| json!(0)),
+                Kind::Message(m) => generate_example_json(&m, visited),
+            }
+        };
+        map.insert(field.name().to_string(), value);
+    }
+
+    visited.remove(desc.full_name());
+    serde_json::Value::Object(map)
+}
+
+/// Convenience wrapper: generate the example JSON for `desc` as a pretty string,
+/// starting with a fresh cycle-tracking set.
+pub fn example_json_for(desc: &MessageDescriptor) -> String {
+    let mut visited = HashSet::new();
+    generate_example_json(desc, &mut visited).to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/desktop/src-tauri/src/grpc/proto_parser.rs
+++ b/apps/desktop/src-tauri/src/grpc/proto_parser.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use prost_reflect::DescriptorPool;
 use protox::Compiler;
 
-use super::{GrpcCallType, GrpcMethodInfo, GrpcServiceInfo};
+use super::{example_json_for, GrpcCallType, GrpcMethodInfo, GrpcServiceInfo};
 
 /// Parse .proto files from a path (file or directory) and return service info.
 pub fn parse_proto_file(
@@ -69,6 +69,7 @@ fn extract_services(pool: &DescriptorPool) -> Vec<GrpcServiceInfo> {
                         input_type: m.input().full_name().to_string(),
                         output_type: m.output().full_name().to_string(),
                         call_type,
+                        example_json: example_json_for(&m.input()),
                     }
                 })
                 .collect();

--- a/apps/desktop/src-tauri/src/grpc/reflection.rs
+++ b/apps/desktop/src-tauri/src/grpc/reflection.rs
@@ -1,41 +1,147 @@
+use std::collections::HashMap;
+
+use futures_util::stream;
+use prost::Message;
 use prost_reflect::DescriptorPool;
+use prost_types::FileDescriptorProto;
 use tonic::transport::Channel;
 
-use super::{GrpcCallType, GrpcMethodInfo, GrpcServiceInfo};
+use super::client::GrpcManager;
+use super::{example_json_for, GrpcCallType, GrpcMethodInfo, GrpcServiceInfo};
 
-/// Discover services from a gRPC server using server reflection.
+// Generated gRPC server reflection (v1) client. The proto is compiled at build
+// time (see build.rs) via protox -> tonic-build, so no system `protoc` is needed.
+mod proto {
+    #![allow(clippy::all)]
+    #![allow(dead_code)]
+    tonic::include_proto!("grpc.reflection.v1");
+}
+
+use proto::server_reflection_client::ServerReflectionClient;
+use proto::server_reflection_request::MessageRequest;
+use proto::server_reflection_response::MessageResponse;
+use proto::ServerReflectionRequest;
+
+/// Discover services from a gRPC server using server reflection (v1).
+///
+/// Reuses the [`GrpcManager`] channel for `address`, lists the server's
+/// services, fetches the file descriptors for each, and builds a
+/// [`DescriptorPool`] usable for dynamic message encoding/decoding — the same
+/// pool produced by loading `.proto` files. Reusing the manager's channel means
+/// subsequent `grpc_call_*` invocations share the connection opened here.
 pub async fn reflect_services(
+    grpc: &GrpcManager,
     address: &str,
 ) -> Result<(Vec<GrpcServiceInfo>, DescriptorPool), String> {
-    let channel = Channel::from_shared(address.to_string())
-        .map_err(|e| format!("Invalid gRPC address: {e}"))?
-        .connect()
-        .await
-        .map_err(|e| format!("Failed to connect: {e}"))?;
+    let channel = grpc.get_channel(address).await?;
+    let mut client = ServerReflectionClient::new(channel);
 
-    // Use the gRPC reflection v1 API
-    let mut client = tonic_reflection_client(channel.clone()).await?;
-
-    // List services
     let services = list_services(&mut client).await?;
 
-    // For each service, get file descriptors and build the pool
-    let mut file_descriptor_bytes: Vec<Vec<u8>> = vec![];
-    for svc_name in &services {
-        if svc_name == "grpc.reflection.v1alpha.ServerReflection"
-            || svc_name == "grpc.reflection.v1.ServerReflection"
-        {
+    // Fetch the file descriptors that define each service. The server returns
+    // each file together with its transitive dependencies as serialized
+    // FileDescriptorProtos. We decode and dedupe by file name (the stable
+    // identity) so the same file requested via two services is added once.
+    let mut files: HashMap<String, FileDescriptorProto> = HashMap::new();
+    for service in &services {
+        if is_reflection_service(service) {
             continue;
         }
-        let fds = get_file_descriptors(&mut client, svc_name).await?;
-        file_descriptor_bytes.extend(fds);
+        for bytes in file_containing_symbol(&mut client, service).await? {
+            let descriptor = FileDescriptorProto::decode(bytes.as_slice())
+                .map_err(|e| format!("Failed to decode file descriptor: {e}"))?;
+            files
+                .entry(descriptor.name().to_string())
+                .or_insert(descriptor);
+        }
     }
 
-    // Build descriptor pool
-    let pool = build_pool_from_bytes(&file_descriptor_bytes)?;
+    let pool = build_pool_from_reflection(files.into_values())?;
+    let service_infos = pool_to_service_infos(&pool);
 
-    let service_infos = pool
-        .services()
+    Ok((service_infos, pool))
+}
+
+fn is_reflection_service(name: &str) -> bool {
+    name == "grpc.reflection.v1.ServerReflection"
+        || name == "grpc.reflection.v1alpha.ServerReflection"
+}
+
+/// Open a single-shot bidi reflection stream, send one request, and return the
+/// server's first response payload.
+async fn send_reflection_request(
+    client: &mut ServerReflectionClient<Channel>,
+    message_request: MessageRequest,
+) -> Result<MessageResponse, String> {
+    let request = ServerReflectionRequest {
+        host: String::new(),
+        message_request: Some(message_request),
+    };
+
+    let mut responses = client
+        .server_reflection_info(stream::once(async move { request }))
+        .await
+        .map_err(|status| format!("Server reflection call failed: {status}"))?
+        .into_inner();
+
+    responses
+        .message()
+        .await
+        .map_err(|status| format!("Server reflection stream error: {status}"))?
+        .ok_or_else(|| "Server returned an empty reflection response".to_string())?
+        .message_response
+        .ok_or_else(|| "Server reflection response had no payload".to_string())
+}
+
+async fn list_services(
+    client: &mut ServerReflectionClient<Channel>,
+) -> Result<Vec<String>, String> {
+    match send_reflection_request(client, MessageRequest::ListServices(String::new())).await? {
+        MessageResponse::ListServicesResponse(resp) => {
+            Ok(resp.service.into_iter().map(|s| s.name).collect())
+        }
+        MessageResponse::ErrorResponse(err) => Err(reflection_error("list services", &err)),
+        _ => Err("Unexpected reflection response to list_services".to_string()),
+    }
+}
+
+async fn file_containing_symbol(
+    client: &mut ServerReflectionClient<Channel>,
+    symbol: &str,
+) -> Result<Vec<Vec<u8>>, String> {
+    let request = MessageRequest::FileContainingSymbol(symbol.to_string());
+    match send_reflection_request(client, request).await? {
+        MessageResponse::FileDescriptorResponse(resp) => Ok(resp.file_descriptor_proto),
+        MessageResponse::ErrorResponse(err) => {
+            Err(reflection_error(&format!("resolve symbol {symbol}"), &err))
+        }
+        _ => Err(format!(
+            "Unexpected reflection response to file_containing_symbol for {symbol}"
+        )),
+    }
+}
+
+fn reflection_error(action: &str, err: &proto::ErrorResponse) -> String {
+    format!(
+        "Server reflection error while trying to {action} (code {}): {}",
+        err.error_code, err.error_message
+    )
+}
+
+/// Build a [`DescriptorPool`] from the `FileDescriptorProto`s gathered via
+/// reflection. Files may arrive in any order; `add_file_descriptor_protos`
+/// resolves imports across the whole batch and skips duplicates by name.
+fn build_pool_from_reflection(
+    files: impl IntoIterator<Item = FileDescriptorProto>,
+) -> Result<DescriptorPool, String> {
+    let mut pool = DescriptorPool::new();
+    pool.add_file_descriptor_protos(files)
+        .map_err(|e| format!("Failed to build descriptor pool: {e}"))?;
+    Ok(pool)
+}
+
+fn pool_to_service_infos(pool: &DescriptorPool) -> Vec<GrpcServiceInfo> {
+    pool.services()
         .map(|svc| {
             let methods = svc
                 .methods()
@@ -52,6 +158,7 @@ pub async fn reflect_services(
                         input_type: m.input().full_name().to_string(),
                         output_type: m.output().full_name().to_string(),
                         call_type,
+                        example_json: example_json_for(&m.input()),
                     }
                 })
                 .collect();
@@ -62,95 +169,5 @@ pub async fn reflect_services(
                 methods,
             }
         })
-        .collect();
-
-    Ok((service_infos, pool))
-}
-
-// Manual gRPC reflection v1alpha client implementation using raw tonic calls.
-// We encode/decode the reflection request/response protobuf manually to avoid
-// needing generated code for the reflection service.
-
-struct ReflectionClient {
-    channel: Channel,
-}
-
-async fn tonic_reflection_client(channel: Channel) -> Result<ReflectionClient, String> {
-    Ok(ReflectionClient { channel })
-}
-
-async fn list_services(client: &mut ReflectionClient) -> Result<Vec<String>, String> {
-    use prost::Message;
-
-    // ServerReflectionRequest { list_services: "" }
-    let mut req_bytes = Vec::new();
-    // field 7 (list_services) = string ""
-    prost::encoding::string::encode(7, &String::new(), &mut req_bytes);
-
-    let response_bytes = call_reflection(&client.channel, req_bytes).await?;
-
-    // Parse the response to extract service names
-    // We look for the list_services_response field (field 6) which contains
-    // repeated ServiceResponse (field 1 = name string)
-    let services = extract_service_names_from_response(&response_bytes);
-    Ok(services)
-}
-
-async fn get_file_descriptors(
-    client: &mut ReflectionClient,
-    service_name: &str,
-) -> Result<Vec<Vec<u8>>, String> {
-    use prost::Message;
-
-    // ServerReflectionRequest { file_containing_symbol: service_name }
-    let mut req_bytes = Vec::new();
-    // field 4 (file_containing_symbol) = string
-    prost::encoding::string::encode(4, &service_name.to_string(), &mut req_bytes);
-
-    let response_bytes = call_reflection(&client.channel, req_bytes).await?;
-
-    // Extract file_descriptor_response (field 4) which contains repeated bytes (field 1)
-    let descriptors = extract_file_descriptors_from_response(&response_bytes);
-    Ok(descriptors)
-}
-
-async fn call_reflection(channel: &Channel, request_bytes: Vec<u8>) -> Result<Vec<u8>, String> {
-    use tonic::codec::{Codec, ProstCodec};
-
-    // Create a streaming request with a single message
-    let request = tonic::Request::new(futures_util::stream::once(async move {
-        prost_types::Any {
-            type_url: String::new(),
-            value: request_bytes,
-        }
-    }));
-
-    // We use a raw unary call instead of trying to do full streaming
-    // For simplicity, use the channel directly with hyper
-
-    // Actually, for a simpler approach, let's just return an error for now
-    // and implement a working reflection client
-    Err("Server reflection requires a more complete implementation. Please load .proto files directly.".to_string())
-}
-
-fn extract_service_names_from_response(bytes: &[u8]) -> Vec<String> {
-    // Simplified protobuf parsing - in production this should use proper generated code
-    vec![]
-}
-
-fn extract_file_descriptors_from_response(bytes: &[u8]) -> Vec<Vec<u8>> {
-    vec![]
-}
-
-fn build_pool_from_bytes(descriptor_bytes: &[Vec<u8>]) -> Result<DescriptorPool, String> {
-    use prost::Message;
-
-    let mut pool = DescriptorPool::new();
-    for bytes in descriptor_bytes {
-        let fds = prost_types::FileDescriptorSet::decode(bytes.as_slice())
-            .map_err(|e| format!("Failed to decode file descriptor: {e}"))?;
-        pool.add_file_descriptor_set(fds)
-            .map_err(|e| format!("Failed to add descriptor to pool: {e}"))?;
-    }
-    Ok(pool)
+        .collect()
 }

--- a/apps/desktop/src-tauri/src/importer/writer.rs
+++ b/apps/desktop/src-tauri/src/importer/writer.rs
@@ -109,6 +109,7 @@ fn write_items(items: &[ImportItem], parent_dir: &Path) -> Result<(), String> {
                     pre_request_script: pre_request_script.clone(),
                     post_response_script: post_response_script.clone(),
                     cookies: None,
+                    grpc: None,
                 };
 
                 let yaml = serde_yaml::to_string(&request_file)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -40,7 +40,7 @@ use commands::git::{
 use commands::greet;
 use commands::grpc::{
     grpc_call_bidi_stream, grpc_call_client_stream, grpc_call_server_stream, grpc_call_unary,
-    grpc_disconnect, grpc_load_proto,
+    grpc_disconnect, grpc_load_proto, grpc_reflect_services,
 };
 use commands::history::{
     clear_history, delete_history_entry, get_history, search_history, AppState,
@@ -320,6 +320,7 @@ pub fn run() {
             unwatch_collection,
             // gRPC commands
             grpc_load_proto,
+            grpc_reflect_services,
             grpc_call_unary,
             grpc_call_server_stream,
             grpc_call_client_stream,

--- a/apps/desktop/src-tauri/src/models/collection.rs
+++ b/apps/desktop/src-tauri/src/models/collection.rs
@@ -75,6 +75,34 @@ pub struct RequestFile {
     pub post_response_script: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cookies: Option<HashMap<String, String>>,
+    /// gRPC-specific state persisted so the request can be reproduced. Discovered
+    /// services are intentionally not stored (they require a live server).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grpc: Option<GrpcRequestFile>,
+}
+
+/// gRPC request state stored in YAML files
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrpcRequestFile {
+    #[serde(default)]
+    pub selected_service: Option<String>,
+    #[serde(default)]
+    pub selected_method: Option<String>,
+    #[serde(default)]
+    pub request_json: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub metadata: Vec<GrpcMetadataFile>,
+}
+
+/// gRPC metadata entry stored in YAML files
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrpcMetadataFile {
+    pub key: String,
+    pub value: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
 }
 
 /// Body stored in YAML files

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -397,6 +397,8 @@ function App() {
                 }));
                 // Now save the actual content
                 await tabStore.save();
+                // Refresh so the sidebar node reflects the saved protocol (e.g. gRPC instead of GET)
+                await useCollectionStore.getState().refreshCollection(collectionPath);
               }
             } catch (err) {
               import("@/stores/toast-store").then(({ useToastStore }) =>

--- a/apps/desktop/src/components/grpc/grpc-view.tsx
+++ b/apps/desktop/src/components/grpc/grpc-view.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useTabStore, useActiveTab } from "@/stores/tab-store";
-import { grpcLoadProto, grpcCallUnary, grpcCallServerStream, grpcCallClientStream, grpcCallBidiStream } from "@/lib/tauri-api";
+import { grpcLoadProto, grpcReflectServices, grpcCallUnary, grpcCallServerStream, grpcCallClientStream, grpcCallBidiStream } from "@/lib/tauri-api";
 import { open } from "@tauri-apps/plugin-dialog";
-import type { GrpcState, GrpcMethodInfo } from "@apiark/types";
-import { Upload, Send, Loader2, Trash2, ArrowDown, ArrowUp, Plus, X, Search, ChevronDown, ChevronRight } from "lucide-react";
+import type { GrpcState, GrpcMethodInfo, GrpcServiceInfo } from "@apiark/types";
+import { CodeEditor } from "@/components/ui/code-editor";
+import { Upload, Radio, Send, Loader2, Trash2, ArrowDown, ArrowUp, Plus, X, Search, ChevronDown, ChevronRight } from "lucide-react";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { UrlBar } from "@/components/request/url-bar";
 import { KeyValueEditor } from "@/components/request/key-value-editor";
@@ -15,6 +16,16 @@ interface StreamMessage {
   timeMs: number;
   direction?: "sent" | "received";
 }
+
+/** gRPC state fields that are persisted to the request file. A patch touching
+ * any of these marks the tab dirty; ephemeral fields (services, loading,
+ * response, error) do not. */
+const PERSISTABLE_GRPC_KEYS: ReadonlyArray<keyof GrpcState> = [
+  "selectedService",
+  "selectedMethod",
+  "requestJson",
+  "metadata",
+];
 
 const CALL_TYPE_ORDER = ["unary", "serverStreaming", "clientStreaming", "bidiStreaming"] as const;
 
@@ -35,6 +46,7 @@ export function GrpcView() {
   const [methodFilter, setMethodFilter] = useState("");
   const [showMetadata, setShowMetadata] = useState(false);
   const [showResponseMeta, setShowResponseMeta] = useState(false);
+  const [reflecting, setReflecting] = useState(false);
   const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -93,13 +105,34 @@ export function GrpcView() {
   const grpc = tab.grpc;
 
   const updateGrpc = (patch: Partial<GrpcState>) => {
+    // Only edits to persistable fields mark the tab dirty (which reveals the
+    // Save button). Ephemeral updates — loading/response/error, and the
+    // services discovered by Reflect — must not, mirroring how HTTP sending
+    // never dirties the tab. Reflect still dirties via selectedService/Method.
+    const marksDirty = PERSISTABLE_GRPC_KEYS.some((k) => k in patch);
     useTabStore.setState((state) => ({
       tabs: state.tabs.map((t) =>
         t.id === state.activeTabId && t.grpc
-          ? { ...t, grpc: { ...t.grpc!, ...patch } }
+          ? { ...t, ...(marksDirty ? { isDirty: true } : {}), grpc: { ...t.grpc!, ...patch } }
           : t,
       ),
     }));
+  };
+
+  // Build the patch for selecting a method: switch the method and, when the
+  // request body is still blank, pre-fill it with the method's generated
+  // example JSON (like Postman does) so the user sees the expected fields.
+  const selectMethodPatch = (
+    svc: GrpcServiceInfo | undefined,
+    methodName: string | null,
+  ): Partial<GrpcState> => {
+    const mtd = svc?.methods.find((m) => m.name === methodName);
+    const patch: Partial<GrpcState> = { selectedMethod: methodName };
+    const methodChanged = methodName !== grpc.selectedMethod;
+    if (mtd?.exampleJson && (methodChanged || isBlankJson(grpc.requestJson))) {
+      patch.requestJson = tryFormatJson(mtd.exampleJson);
+    }
+    return patch;
   };
 
   const handleLoadProto = async () => {
@@ -111,14 +144,45 @@ export function GrpcView() {
       if (!selected) return;
 
       const services = await grpcLoadProto(tab.id, selected as string);
+      const svc = services[0];
       updateGrpc({
         services,
-        selectedService: services[0]?.fullName ?? null,
-        selectedMethod: services[0]?.methods[0]?.name ?? null,
+        selectedService: svc?.fullName ?? null,
+        ...selectMethodPatch(svc, svc?.methods[0]?.name ?? null),
         error: null,
       });
     } catch (err) {
       updateGrpc({ error: String(err) });
+    }
+  };
+
+  const handleReflect = async () => {
+    if (!tab.url.trim()) {
+      updateGrpc({ error: t("grpc.reflectNeedsAddress", { defaultValue: "Enter a server address first." }) });
+      return;
+    }
+    setReflecting(true);
+    updateGrpc({ error: null });
+    try {
+      const services = await grpcReflectServices(tab.id, tab.url);
+      if (services.length === 0) {
+        updateGrpc({ error: t("grpc.reflectNoServices", { defaultValue: "The server exposed no services via reflection." }) });
+        return;
+      }
+      // Prefer the previously selected service if the server still exposes it,
+      // otherwise fall back to the first one returned by reflection.
+      const svc = services.find((s) => s.fullName === grpc.selectedService) ?? services[0];
+      const method = svc?.methods.find((m) => m.name === grpc.selectedMethod)?.name ?? svc?.methods[0]?.name ?? null;
+      updateGrpc({
+        services,
+        selectedService: svc?.fullName ?? null,
+        ...selectMethodPatch(svc, method),
+        error: null,
+      });
+    } catch (err) {
+      updateGrpc({ error: String(err) });
+    } finally {
+      setReflecting(false);
     }
   };
 
@@ -186,13 +250,24 @@ export function GrpcView() {
       <Breadcrumb />
       <UrlBar
         extraActions={
-          <button
-            onClick={handleLoadProto}
-            className="flex items-center gap-1 rounded-lg bg-[var(--color-elevated)] px-2.5 py-2 text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
-          >
-            <Upload className="h-3 w-3" />
-            {t("grpc.loadProto")}
-          </button>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={handleReflect}
+              disabled={reflecting}
+              title={t("grpc.reflectHint", { defaultValue: "Discover services from a reflection-enabled server" })}
+              className="flex items-center gap-1 rounded-lg bg-[var(--color-elevated)] px-2.5 py-2 text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {reflecting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Radio className="h-3 w-3" />}
+              {t("grpc.reflect", { defaultValue: "Reflect" })}
+            </button>
+            <button
+              onClick={handleLoadProto}
+              className="flex items-center gap-1 rounded-lg bg-[var(--color-elevated)] px-2.5 py-2 text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
+            >
+              <Upload className="h-3 w-3" />
+              {t("grpc.loadProto")}
+            </button>
+          </div>
         }
         sendButton={
           <button
@@ -222,7 +297,7 @@ export function GrpcView() {
                   const svc = grpc.services.find((s) => s.fullName === e.target.value);
                   updateGrpc({
                     selectedService: e.target.value,
-                    selectedMethod: svc?.methods[0]?.name ?? null,
+                    ...selectMethodPatch(svc, svc?.methods[0]?.name ?? null),
                   });
                   setMethodFilter("");
                 }}
@@ -240,7 +315,7 @@ export function GrpcView() {
             <MethodBrowser
               methods={selectedSvc.methods}
               selectedMethod={grpc.selectedMethod}
-              onSelectMethod={(name) => updateGrpc({ selectedMethod: name })}
+              onSelectMethod={(name) => updateGrpc(selectMethodPatch(selectedSvc, name))}
               filter={methodFilter}
               onFilterChange={setMethodFilter}
             />
@@ -303,17 +378,16 @@ export function GrpcView() {
                           </button>
                         )}
                       </div>
-                      <textarea
+                      <CodeEditor
                         value={msg}
-                        onChange={(e) => {
+                        onChange={(v) => {
                           const updated = [...clientMessages];
-                          updated[i] = e.target.value;
+                          updated[i] = v;
                           setClientMessages(updated);
                         }}
-                        className="w-full resize-none rounded bg-[var(--color-elevated)] p-2 font-mono text-xs text-[var(--color-text-primary)] outline-none focus:ring-1 focus:ring-blue-500"
+                        language="json"
+                        height="90px"
                         placeholder='{ "field": "value" }'
-                        rows={3}
-                        spellCheck={false}
                       />
                     </div>
                   ))}
@@ -321,18 +395,20 @@ export function GrpcView() {
               </>
             ) : (
               /* Single message input for unary/server streaming */
-              <>
+              <div className="flex h-full flex-col">
                 <label className="mb-1 block text-xs font-medium text-[var(--color-text-muted)]">
                   {t("grpc.requestBody")}
                 </label>
-                <textarea
-                  value={grpc.requestJson}
-                  onChange={(e) => updateGrpc({ requestJson: e.target.value })}
-                  className="h-full w-full resize-none rounded bg-[var(--color-elevated)] p-3 font-mono text-sm text-[var(--color-text-primary)] outline-none focus:ring-1 focus:ring-blue-500"
-                  placeholder='{ "field": "value" }'
-                  spellCheck={false}
-                />
-              </>
+                <div className="min-h-0 flex-1">
+                  <CodeEditor
+                    value={grpc.requestJson}
+                    onChange={(v) => updateGrpc({ requestJson: v })}
+                    language="json"
+                    height="100%"
+                    placeholder='{ "field": "value" }'
+                  />
+                </div>
+              </div>
             )}
           </div>
         </div>
@@ -596,6 +672,13 @@ function CallTypeBadge({ callType }: { callType: string }) {
       {labels[callType] ?? callType}
     </span>
   );
+}
+
+/** A request body that carries no user content yet — safe to overwrite with a
+ * generated example. */
+function isBlankJson(body: string): boolean {
+  const trimmed = body.trim();
+  return trimmed === "" || trimmed === "{}";
 }
 
 function tryFormatJson(body: string): string {

--- a/apps/desktop/src/lib/tauri-api.ts
+++ b/apps/desktop/src/lib/tauri-api.ts
@@ -389,6 +389,10 @@ export async function grpcLoadProto(connectionId: string, protoPath: string): Pr
   return await invoke<import("@apiark/types").GrpcServiceInfo[]>("grpc_load_proto", { connectionId, protoPath });
 }
 
+export async function grpcReflectServices(connectionId: string, address: string): Promise<import("@apiark/types").GrpcServiceInfo[]> {
+  return await invoke<import("@apiark/types").GrpcServiceInfo[]>("grpc_reflect_services", { connectionId, address });
+}
+
 export async function grpcCallUnary(
   connectionId: string,
   address: string,

--- a/apps/desktop/src/stores/tab-store.ts
+++ b/apps/desktop/src/stores/tab-store.ts
@@ -354,13 +354,17 @@ function requestFileToTab(
     : isGraphQL ? "graphql"
     : "http";
 
-  // Initialize gRPC state if needed
+  // Initialize gRPC state if needed. Discovered services are ephemeral (they
+  // depend on a running server via Reflect), so they always start empty; the
+  // rest is restored from the saved file so the request can be reproduced.
   const grpcState: GrpcState | null = protocol === "grpc" ? {
     services: [],
-    selectedService: null,
-    selectedMethod: null,
-    requestJson: "{}",
-    metadata: [emptyKvRow()],
+    selectedService: file.grpc?.selectedService ?? null,
+    selectedMethod: file.grpc?.selectedMethod ?? null,
+    requestJson: file.grpc?.requestJson ?? "{}",
+    metadata: file.grpc?.metadata?.length
+      ? file.grpc.metadata.map((m) => ({ ...m, id: kvId() }))
+      : [emptyKvRow()],
     loading: false,
     response: null,
     error: null,
@@ -431,6 +435,19 @@ function tabToRequestFile(tab: Tab): RequestFile {
     body = { type: tab.body.type, content: tab.body.content };
   }
 
+  // Persist enough gRPC state to reproduce the request. Discovered services are
+  // ephemeral (they require a live server via Reflect) so they are not saved.
+  const grpc = tab.protocol === "grpc" && tab.grpc
+    ? {
+        selectedService: tab.grpc.selectedService,
+        selectedMethod: tab.grpc.selectedMethod,
+        requestJson: tab.grpc.requestJson,
+        metadata: tab.grpc.metadata
+          .filter((m) => m.key.trim())
+          .map(({ key, value, enabled }) => ({ key, value, enabled })),
+      }
+    : undefined;
+
   return {
     name: tab.name,
     method: tab.protocol === "graphql" ? "POST" : tab.method,
@@ -443,6 +460,7 @@ function tabToRequestFile(tab: Tab): RequestFile {
     preRequestScript: tab.preRequestScript || undefined,
     postResponseScript: tab.postResponseScript || undefined,
     tests: tab.testScript || undefined,
+    grpc,
   };
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -256,6 +256,12 @@ export interface RequestFile {
   tests?: string;
   assert?: unknown;
   cookies?: Record<string, string>;
+  grpc?: {
+    selectedService: string | null;
+    selectedMethod: string | null;
+    requestJson: string;
+    metadata: Array<{ key: string; value: string; enabled: boolean }>;
+  };
 }
 
 // ── Environment ──
@@ -456,6 +462,8 @@ export interface GrpcMethodInfo {
   inputType: string;
   outputType: string;
   callType: "unary" | "serverStreaming" | "clientStreaming" | "bidiStreaming";
+  /** Example request JSON with zero-valued fields, generated from the input message descriptor. */
+  exampleJson: string;
 }
 
 export interface GrpcResponse {


### PR DESCRIPTION
Closes #103

## Summary

- Implements gRPC **server reflection** so ApiArk can discover services and methods from a reflection-enabled server, instead of returning the hardcoded stub error and forcing manual `.proto` loading.
- Replaces the empty `extract_*` response parsers with a real `ServerReflectionResponse` decoder feeding the existing `DescriptorPool` builder.
- Wires the previously orphaned reflection path end-to-end: a `grpc_reflect_services` Tauri command + a **Reflect** action in the gRPC view.

## Changes

| File | Change |
|------|--------|
| `src-tauri/proto/reflection.proto` | Vendored `grpc.reflection.v1` (+ `v1alpha` fallback) definitions |
| `src-tauri/build.rs` / `Cargo.toml` / `Cargo.lock` | Compile the reflection proto and add the reflection client deps |
| `src-tauri/src/grpc/reflection.rs` | Real bidi `ServerReflectionInfo` call + response decoding (replaces stub error and empty parsers) |
| `src-tauri/src/grpc/client.rs` / `mod.rs` / `proto_parser.rs` | Plumb discovered descriptors into the pool |
| `src-tauri/src/commands/grpc.rs` / `lib.rs` | Register the `grpc_reflect_services` command |
| `src-tauri/src/models/collection.rs`, `commands/collection.rs`, `importer/writer.rs` | Persist gRPC request state (service/method/body/metadata) in the request YAML |
| `src/components/grpc/grpc-view.tsx`, `App.tsx`, `lib/tauri-api.ts`, `stores/tab-store.ts`, `packages/types` | Reflect action, restore saved gRPC state, sidebar protocol badge refresh |

Discovered services are intentionally **not** persisted — they require a live server, so they are re-fetched via Reflect.

## Test plan

- [x] `cargo check` and `cargo fmt --check` pass (`apps/desktop/src-tauri`)
- [x] `tsc --noEmit` and `eslint .` pass (`apps/desktop`)
- [ ] Manual: point ApiArk at a reflection-enabled gRPC server, hit **Reflect**, confirm services/methods populate and a unary call succeeds