### PR TITLE
fix(environment): allow renaming environments by deleting old file on save

### DIFF
--- a/apps/desktop/src-tauri/src/commands/environment.rs
+++ b/apps/desktop/src-tauri/src/commands/environment.rs
@@ -23,6 +23,7 @@ pub async fn save_environment(
     collection_path: String,
     env: EnvironmentFile,
     scope: Option<String>,
+    old_name: Option<String>,
 ) -> Result<(), String> {
     let path = Path::new(&collection_path);
     let mut env = env;
@@ -33,7 +34,7 @@ pub async fn save_environment(
         };
     }
     tracing::debug!(path = %collection_path, name = %env.name, "Saving environment");
-    environment::save_environment(path, &env)
+    environment::save_environment(path, &env, old_name.as_deref())
 }
 
 /// Resolve all variables for a given environment, merging:

--- a/apps/desktop/src-tauri/src/commands/import_export.rs
+++ b/apps/desktop/src-tauri/src/commands/import_export.rs
@@ -173,7 +173,7 @@ pub fn import_environment(file_path: &str, collection_path: &str) -> Result<Stri
         scope: Default::default(),
     };
 
-    crate::storage::environment::save_environment(Path::new(collection_path), &env)?;
+    crate::storage::environment::save_environment(Path::new(collection_path), &env, None)?;
 
     Ok(name)
 }

--- a/apps/desktop/src-tauri/src/storage/environment.rs
+++ b/apps/desktop/src-tauri/src/storage/environment.rs
@@ -127,7 +127,28 @@ pub fn get_resolved_variables(
 }
 
 /// Save an environment file to disk. Saves to shared or personal directory based on scope.
-pub fn save_environment(collection_path: &Path, env: &EnvironmentFile) -> Result<(), String> {
+/// If `old_name` is provided and differs from the new name, the old file is removed from
+/// both shared and personal directories, handling renames and scope changes correctly.
+pub fn save_environment(
+    collection_path: &Path,
+    env: &EnvironmentFile,
+    old_name: Option<&str>,
+) -> Result<(), String> {
+    // If the name changed, remove the old file from whichever scope directory it may live in
+    if let Some(old) = old_name {
+        if old != env.name {
+            for subdir in ["environments", "environments.local"] {
+                let dir = collection_path.join(".apiark").join(subdir);
+                if let Ok(path) = find_environment_file(&dir, old) {
+                    fs::remove_file(&path).map_err(|e| {
+                        format!("Failed to remove old environment file: {e}")
+                    })?;
+                    break;
+                }
+            }
+        }
+    }
+
     let subdir = match env.scope {
         EnvironmentScope::Personal => "environments.local",
         EnvironmentScope::Shared => "environments",

--- a/apps/desktop/src/components/layout/side-panel.tsx
+++ b/apps/desktop/src/components/layout/side-panel.tsx
@@ -680,8 +680,13 @@ function EnvironmentsPanel({
 
   const handleSave = async (env: EnvironmentData) => {
     if (!collectionPath) return;
+    const oldName = editingEnv?.name;
+    const nameChanged = oldName && oldName !== env.name;
     try {
-      await saveEnvironment(collectionPath, env);
+      await saveEnvironment(collectionPath, env, undefined, oldName);
+      if (nameChanged && activeEnvironmentName === oldName) {
+        setActiveEnvironment(env.name);
+      }
       await loadEnvironments(collectionPath);
       setEditingEnv(null);
     } catch (err) {

--- a/apps/desktop/src/lib/tauri-api.ts
+++ b/apps/desktop/src/lib/tauri-api.ts
@@ -246,8 +246,14 @@ export async function saveEnvironment(
   collectionPath: string,
   env: EnvironmentData,
   scope?: "shared" | "personal",
+  oldName?: string,
 ): Promise<void> {
-  await invoke<void>("save_environment", { collectionPath, env, scope: scope ?? env.scope ?? null });
+  await invoke<void>("save_environment", {
+    collectionPath,
+    env,
+    scope: scope ?? env.scope ?? null,
+    oldName: oldName ?? null,
+  });
 }
 
 // ── History ──


### PR DESCRIPTION
Closes #114

## Summary

- When renaming an environment via the inline editor, `save_environment` created a new YAML file but never deleted the old one, leaving a duplicate on disk
- Added an `old_name` parameter to `save_environment` in both Rust and frontend layers; when the name changes, the old file is found and removed from either shared or personal scope directories
- Fixed a timing issue where the active environment name was updated after `loadEnvironments` triggered `refreshResolvedVariables` against the stale name, causing a "not found" error toast

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src-tauri/src/storage/environment.rs` | Accept `old_name` param; delete old file on rename |
| `apps/desktop/src-tauri/src/commands/environment.rs` | Forward `old_name` from Tauri command |
| `apps/desktop/src-tauri/src/commands/import_export.rs` | Pass `None` for new environments |
| `apps/desktop/src/lib/tauri-api.ts` | Accept `oldName` in frontend API wrapper |
| `apps/desktop/src/components/layout/side-panel.tsx` | Pass old name on save; update active env before reload |

## Test Plan

- [x] Renamed an environment in the sidebar → old name disappeared, new name appeared, no duplicates
- [x] Renamed the currently active environment → no "Environment not found" error toast, variables resolved correctly
- [x] Creating a new environment still works (no old name to delete)
- [x] Editing variables without changing the name still works
- [x] `cargo check` passes with no new warnings

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format