### PR TITLE
feat(environments): add per-environment color selection

### DIFF
--- a/apps/desktop/src-tauri/src/commands/import_export.rs
+++ b/apps/desktop/src-tauri/src/commands/import_export.rs
@@ -171,6 +171,7 @@ pub fn import_environment(file_path: &str, collection_path: &str) -> Result<Stri
         variables,
         secrets: Vec::new(),
         scope: Default::default(),
+        color: None,
     };
 
     crate::storage::environment::save_environment(Path::new(collection_path), &env)?;

--- a/apps/desktop/src-tauri/src/models/environment.rs
+++ b/apps/desktop/src-tauri/src/models/environment.rs
@@ -13,6 +13,9 @@ pub struct EnvironmentFile {
     /// Determined by which directory the file is in.
     #[serde(default)]
     pub scope: EnvironmentScope,
+    /// Optional hex colour (e.g. "#10b981") for visual identification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -73,7 +73,7 @@ function App() {
   const [zenMode, setZenMode] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const urlBarRef = useRef<HTMLInputElement>(null);
-  const envSelectorRef = useRef<HTMLSelectElement>(null);
+  const envSelectorRef = useRef<HTMLButtonElement>(null);
   const { isCompact } = useResponsive();
 
   useTheme();

--- a/apps/desktop/src/__tests__/components/header-environment-selector.test.tsx
+++ b/apps/desktop/src/__tests__/components/header-environment-selector.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HeaderEnvironmentSelector } from "@/components/environment/header-environment-selector";
+import { useEnvironmentStore } from "@/stores/environment-store";
+import type { EnvironmentData } from "@apiark/types";
+
+vi.mock("@/lib/tauri-api", () => ({
+  loadEnvironments: vi.fn().mockResolvedValue([]),
+  getResolvedVariables: vi.fn().mockResolvedValue({}),
+  loadRootDotenv: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        "environment.noEnvironment": "No Environment",
+        "environment.noEnvironments":
+          "Create an environment to manage variables across requests",
+        "environment.title": "Environments",
+      })[key] ?? key,
+  }),
+}));
+
+function env(name: string): EnvironmentData {
+  return { name, variables: {}, secrets: [] };
+}
+
+describe("HeaderEnvironmentSelector", () => {
+  beforeEach(() => {
+    useEnvironmentStore.setState({
+      environments: [],
+      activeEnvironmentName: null,
+      activeCollectionPath: null,
+      runtimeOverrides: {},
+    });
+  });
+
+  it("renders the active environment in the trigger", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local"), env("Production")],
+      activeEnvironmentName: "Production",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Production");
+  });
+
+  it("renders one option per environment plus 'No Environment'", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local"), env("Production")],
+      activeEnvironmentName: "Local",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    fireEvent.click(screen.getByRole("combobox"));
+
+    expect(screen.getByRole("option", { name: "Local" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Production" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "No Environment" })).toBeInTheDocument();
+  });
+
+  it("switches the active environment when an option is clicked", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local"), env("Production")],
+      activeEnvironmentName: "Local",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "Production" }));
+
+    expect(useEnvironmentStore.getState().activeEnvironmentName).toBe("Production");
+  });
+
+  it("clears the active environment when 'No Environment' is chosen", () => {
+    useEnvironmentStore.setState({
+      environments: [env("Local")],
+      activeEnvironmentName: "Local",
+    });
+
+    render(<HeaderEnvironmentSelector />);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "No Environment" }));
+
+    expect(useEnvironmentStore.getState().activeEnvironmentName).toBeNull();
+  });
+
+  it("renders a 'No Environment' pill when there are no environments", () => {
+    useEnvironmentStore.setState({ environments: [], activeEnvironmentName: null });
+
+    render(<HeaderEnvironmentSelector />);
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByText("No Environment")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/collection/collection-sidebar.tsx
+++ b/apps/desktop/src/components/collection/collection-sidebar.tsx
@@ -16,7 +16,7 @@ type SidebarSection = "collections" | "environments" | "history";
 interface CollectionSidebarProps {
   onOpenSettings?: () => void;
   collapsed?: boolean;
-  envSelectorRef?: React.RefObject<HTMLSelectElement | null>;
+  envSelectorRef?: React.RefObject<HTMLButtonElement | null>;
   onOpenImport?: () => void;
 }
 

--- a/apps/desktop/src/components/environment/environment-selector.tsx
+++ b/apps/desktop/src/components/environment/environment-selector.tsx
@@ -1,16 +1,17 @@
 import { useEffect, forwardRef } from "react";
 import { useTranslation } from "react-i18next";
+import * as Select from "@radix-ui/react-select";
+import { ChevronDown } from "lucide-react";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { useCollectionStore } from "@/stores/collection-store";
 
-export const EnvironmentSelector = forwardRef<HTMLSelectElement>(
+export const EnvironmentSelector = forwardRef<HTMLButtonElement>(
   function EnvironmentSelector(_props, ref) {
     const { t } = useTranslation();
     const { environments, activeEnvironmentName, setActiveEnvironment, loadEnvironments } =
       useEnvironmentStore();
     const { collections } = useCollectionStore();
 
-    // Load environments when collections change
     useEffect(() => {
       if (collections.length > 0) {
         const firstCollection = collections[0];
@@ -28,23 +29,78 @@ export const EnvironmentSelector = forwardRef<HTMLSelectElement>(
       );
     }
 
+    const activeEnv = environments.find((e) => e.name === activeEnvironmentName);
+
     return (
-      <select
-        ref={ref}
-        data-tour="environment"
-        value={activeEnvironmentName ?? ""}
-        onChange={(e) =>
-          setActiveEnvironment(e.target.value || null)
-        }
-        className="w-full rounded bg-[var(--color-elevated)] px-2 py-1.5 text-xs text-[var(--color-text-primary)] outline-none focus:ring-1 focus:ring-blue-500"
+      <Select.Root
+        value={activeEnvironmentName ?? "__none__"}
+        onValueChange={(v) => setActiveEnvironment(v === "__none__" ? null : v)}
       >
-        <option value="">{t("environment.noEnvironment")}</option>
-        {environments.map((env) => (
-          <option key={env.name} value={env.name}>
-            {env.name}
-          </option>
-        ))}
-      </select>
+        <Select.Trigger
+          ref={ref}
+          data-tour="environment"
+          className="flex w-full cursor-pointer items-center gap-1.5 rounded bg-[var(--color-elevated)] px-2 py-1.5 text-xs text-[var(--color-text-primary)] outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          {activeEnv?.color && (
+            <span
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{ backgroundColor: activeEnv.color }}
+            />
+          )}
+          <span className="truncate">
+            <Select.Value placeholder={t("environment.noEnvironment")} />
+          </span>
+          <Select.Icon className="ml-auto shrink-0 text-[var(--color-text-dimmed)]">
+            <ChevronDown className="h-3 w-3" />
+          </Select.Icon>
+        </Select.Trigger>
+
+        <Select.Portal>
+          <Select.Content
+            position="popper"
+            sideOffset={4}
+            className="z-50 max-h-[260px] overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-elevated)] shadow-lg"
+          >
+            <Select.Viewport className="p-1">
+              <SelectItem value="__none__">
+                <span className="text-[var(--color-text-dimmed)]">
+                  {t("environment.noEnvironment")}
+                </span>
+              </SelectItem>
+              {environments.map((env) => (
+                <SelectItem key={env.name} value={env.name}>
+                  {env.color && (
+                    <span
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: env.color }}
+                    />
+                  )}
+                  {env.name}
+                </SelectItem>
+              ))}
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
     );
   },
 );
+
+function SelectItem({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: string;
+}) {
+  return (
+    <Select.Item
+      value={value}
+      className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-xs text-[var(--color-text-primary)] outline-none data-[highlighted]:bg-[var(--color-accent)]/10 data-[highlighted]:text-[var(--color-accent)] data-[state=checked]:bg-[var(--color-accent)]/10"
+    >
+      <Select.ItemText className="flex items-center gap-1.5">
+        {children}
+      </Select.ItemText>
+    </Select.Item>
+  );
+}

--- a/apps/desktop/src/components/environment/header-environment-selector.tsx
+++ b/apps/desktop/src/components/environment/header-environment-selector.tsx
@@ -1,0 +1,97 @@
+import { useTranslation } from "react-i18next";
+import * as Select from "@radix-ui/react-select";
+import { ChevronDown } from "lucide-react";
+import { useEnvironmentStore } from "@/stores/environment-store";
+
+export function HeaderEnvironmentSelector() {
+  const { t } = useTranslation();
+  const environments = useEnvironmentStore((s) => s.environments);
+  const activeEnvironmentName = useEnvironmentStore((s) => s.activeEnvironmentName);
+  const setActiveEnvironment = useEnvironmentStore((s) => s.setActiveEnvironment);
+
+  if (environments.length === 0) {
+    return (
+      <span
+        className="flex shrink-0 items-center rounded-lg border border-dashed border-[var(--color-border)] px-3 py-2 text-sm text-[var(--color-text-dimmed)]"
+        title={t("environment.noEnvironments")}
+      >
+        {t("environment.noEnvironment")}
+      </span>
+    );
+  }
+
+  const activeEnv = environments.find((e) => e.name === activeEnvironmentName);
+
+  return (
+    <Select.Root
+      value={activeEnvironmentName ?? "__none__"}
+      onValueChange={(v) => setActiveEnvironment(v === "__none__" ? null : v)}
+    >
+      <Select.Trigger
+        aria-label={t("environment.title")}
+        className="flex max-w-[180px] shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-sm text-[var(--color-text-primary)] outline-none transition-colors focus:border-[var(--color-accent)]/50 focus:ring-2 focus:ring-[var(--color-accent)]/20"
+        style={
+          activeEnv?.color
+            ? {
+                borderColor: activeEnv.color,
+                backgroundColor: `${activeEnv.color}1A`,
+              }
+            : { backgroundColor: "var(--color-elevated)" }
+        }
+      >
+        <span className="truncate">
+          <Select.Value placeholder={t("environment.noEnvironment")} />
+        </span>
+        <Select.Icon className="ml-auto shrink-0 text-[var(--color-text-dimmed)]">
+          <ChevronDown className="h-3.5 w-3.5" />
+        </Select.Icon>
+      </Select.Trigger>
+
+      <Select.Portal>
+        <Select.Content
+          position="popper"
+          sideOffset={4}
+          className="z-50 max-h-[260px] overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-elevated)] shadow-lg"
+        >
+          <Select.Viewport className="p-1">
+            <SelectItem value="__none__">
+              <span className="text-[var(--color-text-dimmed)]">
+                {t("environment.noEnvironment")}
+              </span>
+            </SelectItem>
+            {environments.map((env) => (
+              <SelectItem key={env.name} value={env.name}>
+                {env.color && (
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: env.color }}
+                  />
+                )}
+                {env.name}
+              </SelectItem>
+            ))}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
+function SelectItem({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: string;
+}) {
+  return (
+    <Select.Item
+      value={value}
+      className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-[var(--color-text-primary)] outline-none data-[highlighted]:bg-[var(--color-accent)]/10 data-[highlighted]:text-[var(--color-accent)] data-[state=checked]:bg-[var(--color-accent)]/10"
+    >
+      <Select.ItemText className="flex items-center gap-1.5">
+        {children}
+      </Select.ItemText>
+    </Select.Item>
+  );
+}

--- a/apps/desktop/src/components/layout/side-panel.tsx
+++ b/apps/desktop/src/components/layout/side-panel.tsx
@@ -18,7 +18,7 @@ import { AuditPanel } from "@/components/audit/audit-panel";
 
 interface SidePanelProps {
   activeView: ActivityView;
-  envSelectorRef?: React.RefObject<HTMLSelectElement | null>;
+  envSelectorRef?: React.RefObject<HTMLButtonElement | null>;
   onOpenMock?: () => void;
   onOpenMonitor?: () => void;
   onOpenDocs?: () => void;
@@ -659,7 +659,7 @@ function NewCollectionDialog({
 function EnvironmentsPanel({
   envSelectorRef,
 }: {
-  envSelectorRef?: React.RefObject<HTMLSelectElement | null>;
+  envSelectorRef?: React.RefObject<HTMLButtonElement | null>;
 }) {
   const { t } = useTranslation();
   const { environments, activeEnvironmentName, setActiveEnvironment, loadEnvironments } =
@@ -728,7 +728,8 @@ function EnvironmentsPanel({
 
   const handleCreateNew = async (name: string) => {
     if (!collectionPath) return;
-    const env: EnvironmentData = { name, variables: {}, secrets: [] };
+    const color = ["#10b981", "#3b82f6", "#8b5cf6", "#ec4899", "#f97316", "#eab308", "#06b6d4", "#14b8a6", "#a855f7", "#ef4444"][environments.length % 10];
+    const env: EnvironmentData = { name, variables: {}, secrets: [], color };
     try {
       await saveEnvironment(collectionPath, env);
       await loadEnvironments(collectionPath);
@@ -845,6 +846,12 @@ function EnvironmentsPanel({
               }`}
             >
               <div className="flex items-center gap-1.5 truncate">
+                {env.color && (
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: env.color }}
+                  />
+                )}
                 <span className="truncate">{env.name}</span>
                 {env.scope === "personal" && (
                   <span className="shrink-0 rounded bg-amber-500/15 px-1 py-0.5 text-[8px] font-bold text-amber-400">
@@ -890,13 +897,20 @@ function EnvironmentEditor({
   );
 
   const [scope, setScope] = useState<"shared" | "personal">(env.scope ?? "shared");
+  const [color, setColor] = useState(env.color ?? "");
 
   const handleSave = () => {
     const vars: Record<string, string> = {};
     for (const v of variables) {
       if (v.key.trim()) vars[v.key.trim()] = v.value;
     }
-    onSave({ ...env, name: name.trim() || env.name, variables: vars, scope });
+    onSave({
+      ...env,
+      name: name.trim() || env.name,
+      variables: vars,
+      scope,
+      color: color || undefined,
+    });
   };
 
   const updateVar = (index: number, field: "key" | "value", val: string) => {
@@ -961,6 +975,43 @@ function EnvironmentEditor({
         >
           Personal
         </button>
+      </div>
+
+      {/* Color picker */}
+      <div className="flex items-center gap-2 rounded bg-[var(--color-elevated)] px-2 py-1.5">
+        <span className="text-[10px] text-[var(--color-text-dimmed)]">Color:</span>
+        <div className="flex items-center gap-1">
+          {["#10b981","#3b82f6","#8b5cf6","#ec4899","#f97316","#eab308","#06b6d4","#14b8a6","#a855f7","#ef4444"].map((c) => (
+            <button
+              key={c}
+              onClick={() => setColor(color === c ? "" : c)}
+              className={`h-4 w-4 rounded-full transition-transform ${
+                color === c ? "scale-125 ring-1 ring-white" : ""
+              }`}
+              style={{ backgroundColor: c }}
+              title={c}
+            />
+          ))}
+          <label className="relative flex h-4 w-4 cursor-pointer items-center justify-center rounded-full border border-dashed border-[var(--color-border)] hover:border-[var(--color-text-muted)]">
+            <Plus className="h-3 w-3 text-[var(--color-text-dimmed)]" />
+            <input
+              type="color"
+              value={color || "#000000"}
+              onChange={(e) => setColor(e.target.value)}
+              className="absolute inset-0 cursor-pointer opacity-0"
+              title="Custom color"
+            />
+          </label>
+          {color && (
+            <button
+              onClick={() => setColor("")}
+              className="ml-1 text-[10px] text-[var(--color-text-dimmed)] hover:text-[var(--color-text-secondary)]"
+              title="Remove color"
+            >
+              Clear
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Variables */}

--- a/apps/desktop/src/components/layout/status-bar.tsx
+++ b/apps/desktop/src/components/layout/status-bar.tsx
@@ -20,6 +20,8 @@ export function StatusBar({ onToggleTerminal, terminalOpen }: StatusBarProps) {
   const [appVersion, setAppVersion] = useState("");
   useEffect(() => { getVersion().then(setAppVersion); }, []);
   const activeEnv = useEnvironmentStore((s) => s.activeEnvironmentName);
+  const environments = useEnvironmentStore((s) => s.environments);
+  const activeEnvData = environments.find((e) => e.name === activeEnv);
   const collections = useCollectionStore((s) => s.collections);
   const mockServers = useMockStore((s) => s.servers);
   const monitors = useMonitorStore((s) => s.monitors);
@@ -45,6 +47,12 @@ export function StatusBar({ onToggleTerminal, terminalOpen }: StatusBarProps) {
       <div className="flex items-center gap-3">
         {activeEnv && (
           <span className="flex items-center gap-1 text-[var(--color-text-muted)]">
+            {activeEnvData?.color && (
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: activeEnvData.color }}
+              />
+            )}
             <Globe className="h-4 w-4" />
             {activeEnv}
           </span>

--- a/apps/desktop/src/components/request/url-bar.tsx
+++ b/apps/desktop/src/components/request/url-bar.tsx
@@ -6,6 +6,7 @@ import type { HttpMethod, EnvironmentData } from "@apiark/types";
 import { Loader2, Send, AlertCircle, Check } from "lucide-react";
 import * as Popover from "@radix-ui/react-popover";
 import { HintTooltip } from "@/components/ui/hint-tooltip";
+import { HeaderEnvironmentSelector } from "@/components/environment/header-environment-selector";
 import { saveEnvironment } from "@/lib/tauri-api";
 
 const METHODS: HttpMethod[] = [
@@ -334,6 +335,9 @@ export const UrlBar = forwardRef<HTMLInputElement, UrlBarProps>(function UrlBar(
           ))}
         </select>
       )}
+
+      {/* Environment selector */}
+      <HeaderEnvironmentSelector />
 
       {/* URL input with variable highlighting overlay */}
       <div className="relative flex-1">

--- a/apps/desktop/src/components/request/url-bar.tsx
+++ b/apps/desktop/src/components/request/url-bar.tsx
@@ -336,9 +336,6 @@ export const UrlBar = forwardRef<HTMLInputElement, UrlBarProps>(function UrlBar(
         </select>
       )}
 
-      {/* Environment selector */}
-      <HeaderEnvironmentSelector />
-
       {/* URL input with variable highlighting overlay */}
       <div className="relative flex-1">
         <input
@@ -384,6 +381,9 @@ export const UrlBar = forwardRef<HTMLInputElement, UrlBarProps>(function UrlBar(
           </div>
         )}
       </div>
+
+      {/* Environment selector */}
+      <HeaderEnvironmentSelector />
 
       {/* Extra protocol-specific actions */}
       {extraActions}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -265,6 +265,8 @@ export interface EnvironmentData {
   variables: Record<string, string>;
   secrets: string[];
   scope?: "shared" | "personal";
+  /** Hex color (e.g. "#10b981") for visual identification in the UI */
+  color?: string;
 }
 
 // ── History Entry (matches Rust HistoryEntry) ──


### PR DESCRIPTION
Closes #115

## Summary
- Adds an optional `color` field to environment models (TS + Rust)
- Color picker in the environment editor with 10 presets and a custom color input
- Header environment selector shows a tinted background + colored border
- Side panel and dropdown options show color dots
- Status bar shows a color dot next to the active environment name
- Auto-assigns a color when creating a new environment (cycles through presets)

## Changes

| File | Change |
|------|--------|
| `packages/types/src/index.ts` | Add `color?: string` to `EnvironmentData` |
| `apps/desktop/src-tauri/src/models/environment.rs` | Add `color: Option<String>` to `EnvironmentFile` |
| `apps/desktop/src-tauri/src/commands/import_export.rs` | Add `color: None` on import |
| `apps/desktop/src/components/environment/header-environment-selector.tsx` | New Radix Select with color display |
| `apps/desktop/src/components/environment/environment-selector.tsx` | Convert to Radix Select with color dots |
| `apps/desktop/src/components/layout/side-panel.tsx` | Color picker in editor, color dots in list, auto-color on create |
| `apps/desktop/src/components/layout/status-bar.tsx` | Color dot next to active env name |
| `apps/desktop/src/components/request/url-bar.tsx` | Mount HeaderEnvironmentSelector |
| `apps/desktop/src/__tests__/components/header-environment-selector.test.tsx` | Update test for Radix Select |
| `apps/desktop/src/App.tsx`, `collection-sidebar.tsx` | Ref type updates for Radix Select |

## Test Plan
- [x] TypeScript compiles with no errors
- [x] Rust compiles with no errors
- [x] All 31 tests pass
- [x] `HeaderEnvironmentSelector` renders and switches environments correctly