### PR TITLE
fix(curl-import): handle -b / --cookie flag so cookies aren't silently dropped

### DIFF
--- a/apps/desktop/src-tauri/src/http/curl.rs
+++ b/apps/desktop/src-tauri/src/http/curl.rs
@@ -58,6 +58,12 @@ pub fn parse_curl(input: &str) -> Result<ParsedCurlRequest, String> {
                     ));
                 }
             }
+            "-b" | "--cookie" => {
+                i += 1;
+                if let Some(cookie_val) = tokens.get(i) {
+                    headers.insert("Cookie".to_string(), cookie_val.clone());
+                }
+            }
             "-k" | "--insecure" => {
                 verify_ssl = false;
             }
@@ -236,5 +242,29 @@ mod tests {
     fn test_insecure_flag() {
         let result = parse_curl("curl -k https://example.com").unwrap();
         assert!(!result.verify_ssl);
+    }
+
+    #[test]
+    fn test_cookie_flag() {
+        // short flag -b
+        let result =
+            parse_curl("curl 'https://example.com/api/data' -b 'session=abc123; token=xyz' -H 'accept: application/json'")
+                .unwrap();
+        assert_eq!(
+            result.headers.get("Cookie").map(String::as_str),
+            Some("session=abc123; token=xyz")
+        );
+        assert_eq!(
+            result.headers.get("accept").map(String::as_str),
+            Some("application/json")
+        );
+
+        // long flag --cookie
+        let result =
+            parse_curl("curl https://example.com --cookie 'auth=tok1'").unwrap();
+        assert_eq!(
+            result.headers.get("Cookie").map(String::as_str),
+            Some("auth=tok1")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #66 — When importing a curl command that uses `-b` or `--cookie` to pass cookies, the parser silently dropped both the flag and the cookie value. This PR adds a match arm for those flags so the cookie string is preserved as a `Cookie` header on the imported request, exactly matching the behaviour users expect from Postman, Insomnia, and similar tools.

## What changed

**`apps/desktop/src-tauri/src/http/curl.rs`**

- **Problem:** The `parse_curl()` match block had no arm for `-b` / `--cookie`. Both tokens (the flag and the following cookie value) fell into the `_` branch and were silently discarded, so cookie-authenticated endpoints always failed after import.
- **Fix:** Added a `"-b" | "--cookie"` arm that advances the iterator, reads the next token (the cookie string), and inserts it into `headers` under the key `"Cookie"`. This is the same pattern used by every other two-token flag in the parser (`-H`, `-d`, `-u`), so the approach is consistent with existing code.
- **Why this approach:** The cookie value is inserted as a plain `Cookie` header. This keeps the import layer simple and agnostic of any future dedicated cookie-management feature (#29, #40); those features can later consume or migrate the `Cookie` header as they see fit.
- **Test added:** `test_cookie_flag` verifies both the short form (`-b 'session=abc123; token=xyz'`) and the long form (`--cookie 'auth=tok1'`) are correctly imported, and that other headers alongside `-b` are unaffected.

## Acceptance criteria checklist

- [x] `-b 'session=abc123; token=xyz'` is parsed and appears as `Cookie: session=abc123; token=xyz` in the imported request
- [x] `--cookie 'auth=tok1'` works identically
- [x] Other headers in the same command are not affected
- [x] No warning or error is shown; the request imports cleanly
- [x] Existing tests (`test_simple_get`, `test_post_with_data`, `test_basic_auth`, `test_insecure_flag`) continue to pass

## Testing

1. Build the desktop app (`cargo tauri dev` from `apps/desktop`).
2. Open the curl import dialog.
3. Paste: `curl 'https://httpbin.org/cookies' -b 'session=abc123; token=xyz' -H 'accept: application/json'`
4. Verify the imported request shows a `Cookie` header with value `session=abc123; token=xyz` and an `accept` header with value `application/json`.
5. Send the request — `https://httpbin.org/cookies` echoes back the cookies it received; confirm `session` and `token` appear in the response.
6. Repeat with `--cookie` instead of `-b` — same result.
7. Edge case: paste a curl with no `-b` flag at all — verify no `Cookie` header is added and nothing else regresses.

For the unit tests alone:
```
cd apps/desktop/src-tauri
cargo test curl
```
All five tests should pass.

## Notes

- No schema changes, no database changes, no new dependencies.
- No server-side changes; this is purely a parsing fix in the Rust import layer.
- If the project later adds a dedicated cookie jar / cookie management UI (#29, #40), the `Cookie` header inserted here can be migrated at that point without any breaking changes to this fix.